### PR TITLE
회원가입 기능 구현

### DIFF
--- a/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
+++ b/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
@@ -10,6 +10,9 @@
 		4403B40D25494B5400503E17 /* InputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4403B40C25494B5400503E17 /* InputView.swift */; };
 		4403B41025494C1000503E17 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 4403B40F25494C1000503E17 /* .swiftlint.yml */; };
 		447C96F82549745B008D326F /* SignUpViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 447C96F72549745B008D326F /* SignUpViewController.swift */; };
+		44E910A3254ACEC7000949A1 /* SignUpUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44E910A2254ACEC7000949A1 /* SignUpUseCase.swift */; };
+		44E910A6254ACF2A000949A1 /* SignUpInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44E910A5254ACF2A000949A1 /* SignUpInfo.swift */; };
+		44E910A9254AD1C7000949A1 /* SignUpEndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44E910A8254AD1C7000949A1 /* SignUpEndPoint.swift */; };
 		800722403CD0E1D517104752 /* Pods_IssueTracker.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4B26D7853D2AAE8891129546 /* Pods_IssueTracker.framework */; };
 		B95A6C70254AA86800D9EC66 /* NetworkRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B95A6C6F254AA86800D9EC66 /* NetworkRequest.swift */; };
 		B980375D25484A14002FF4BF /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B980375C25484A14002FF4BF /* AppDelegate.swift */; };
@@ -26,6 +29,9 @@
 		4403B40C25494B5400503E17 /* InputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputView.swift; sourceTree = "<group>"; };
 		4403B40F25494C1000503E17 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		447C96F72549745B008D326F /* SignUpViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpViewController.swift; sourceTree = "<group>"; };
+		44E910A2254ACEC7000949A1 /* SignUpUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpUseCase.swift; sourceTree = "<group>"; };
+		44E910A5254ACF2A000949A1 /* SignUpInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpInfo.swift; sourceTree = "<group>"; };
+		44E910A8254AD1C7000949A1 /* SignUpEndPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpEndPoint.swift; sourceTree = "<group>"; };
 		4B26D7853D2AAE8891129546 /* Pods_IssueTracker.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_IssueTracker.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		98995B803699302D8FC3AB2F /* Pods-IssueTracker.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IssueTracker.release.xcconfig"; path = "Target Support Files/Pods-IssueTracker/Pods-IssueTracker.release.xcconfig"; sourceTree = "<group>"; };
 		B95A6C6F254AA86800D9EC66 /* NetworkRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkRequest.swift; sourceTree = "<group>"; };
@@ -55,9 +61,20 @@
 		447C96F625497449008D326F /* SignUpScene */ = {
 			isa = PBXGroup;
 			children = (
+				44E910A1254ACEB1000949A1 /* Model */,
 				B9BF5A5E25499F640052910D /* Controller */,
 			);
 			path = SignUpScene;
+			sourceTree = "<group>";
+		};
+		44E910A1254ACEB1000949A1 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				44E910A2254ACEC7000949A1 /* SignUpUseCase.swift */,
+				44E910A8254AD1C7000949A1 /* SignUpEndPoint.swift */,
+				44E910A5254ACF2A000949A1 /* SignUpInfo.swift */,
+			);
+			path = Model;
 			sourceTree = "<group>";
 		};
 		9E4FCDB20009D47AC3AF8E66 /* Pods */ = {
@@ -277,11 +294,14 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				44E910A9254AD1C7000949A1 /* SignUpEndPoint.swift in Sources */,
 				B95A6C70254AA86800D9EC66 /* NetworkRequest.swift in Sources */,
 				B980376125484A14002FF4BF /* LoginViewController.swift in Sources */,
 				4403B40D25494B5400503E17 /* InputView.swift in Sources */,
+				44E910A6254ACF2A000949A1 /* SignUpInfo.swift in Sources */,
 				B980375D25484A14002FF4BF /* AppDelegate.swift in Sources */,
 				B980375F25484A14002FF4BF /* SceneDelegate.swift in Sources */,
+				44E910A3254ACEC7000949A1 /* SignUpUseCase.swift in Sources */,
 				B9BF5A6125499FA60052910D /* NetworkService.swift in Sources */,
 				447C96F82549745B008D326F /* SignUpViewController.swift in Sources */,
 			);

--- a/iOS/IssueTracker/IssueTracker/Common/Model/NetworkRequest.swift
+++ b/iOS/IssueTracker/IssueTracker/Common/Model/NetworkRequest.swift
@@ -13,6 +13,7 @@ enum RequestMethod: String {
 }
 
 protocol RequestType {
-    var url: URL { get }
+    var url: URL? { get }
     var method: RequestMethod { get }
+    var body: Data? { get }
 }

--- a/iOS/IssueTracker/IssueTracker/Common/Model/NetworkService.swift
+++ b/iOS/IssueTracker/IssueTracker/Common/Model/NetworkService.swift
@@ -27,9 +27,13 @@ final class NetworkService: NetworkServiceProviding {
     }
     
     func request(requestType: RequestType, completionHandler: @escaping (Result<Data, NetworkError>) -> Void) {
-        
-        var urlRequest = URLRequest(url: requestType.url)
+        guard let url = requestType.url else {
+            completionHandler(.failure(.invalidURL))
+            return
+        }
+        var urlRequest = URLRequest(url: url)
         urlRequest.httpMethod = requestType.method.rawValue
+        urlRequest.httpBody = requestType.body
         session.dataTask(with: urlRequest) { (data, response, error) in
             if let error = error {
                 completionHandler(.failure(.requestFailed(msg: error.localizedDescription)))

--- a/iOS/IssueTracker/IssueTracker/SignUpScene/Model/SignUpEndPoint.swift
+++ b/iOS/IssueTracker/IssueTracker/SignUpScene/Model/SignUpEndPoint.swift
@@ -1,0 +1,15 @@
+//
+//  SignUpEndPoint.swift
+//  IssueTracker
+//
+//  Created by TTOzzi on 2020/10/29.
+//
+
+import Foundation
+
+struct SignUpEndPoint: RequestType {
+    
+    let url: URL? = URL(string: "api/user/signup")
+    let method: RequestMethod = .post
+    let body: Data?
+}

--- a/iOS/IssueTracker/IssueTracker/SignUpScene/Model/SignUpInfo.swift
+++ b/iOS/IssueTracker/IssueTracker/SignUpScene/Model/SignUpInfo.swift
@@ -1,0 +1,16 @@
+//
+//  SignUpInfo.swift
+//  IssueTracker
+//
+//  Created by TTOzzi on 2020/10/29.
+//
+
+import Foundation
+
+struct SignUpInfo: Encodable {
+    
+    let email: String
+    let password1: String
+    let password2: String
+    let nickname: String
+}

--- a/iOS/IssueTracker/IssueTracker/SignUpScene/Model/SignUpUseCase.swift
+++ b/iOS/IssueTracker/IssueTracker/SignUpScene/Model/SignUpUseCase.swift
@@ -1,0 +1,42 @@
+//
+//  SignUpUseCase.swift
+//  IssueTracker
+//
+//  Created by TTOzzi on 2020/10/29.
+//
+
+import Foundation
+
+enum SignUpUseCaseError: Error {
+    case encodingError
+    case networkError(message: String)
+}
+
+protocol SignUpUseCaseType {
+    func signUp(with info: SignUpInfo, completion: @escaping (SignUpUseCaseError?) -> Void)
+}
+
+final class SignUpUseCase: SignUpUseCaseType {
+    
+    private let networkService: NetworkServiceProviding
+    
+    init(networkService: NetworkServiceProviding) {
+        self.networkService = networkService
+    }
+    
+    func signUp(with info: SignUpInfo, completion: @escaping (SignUpUseCaseError?) -> Void) {
+        guard let data = try? JSONEncoder().encode(info) else {
+            completion(.encodingError)
+            return
+        }
+        let request = SignUpEndPoint(body: data)
+        networkService.request(requestType: request) { result in
+            switch result {
+            case .success:
+                completion(nil)
+            case let .failure(error):
+                completion(.networkError(message: error.localizedDescription))
+            }
+        }
+    }
+}


### PR DESCRIPTION
회원가입에 필요한 정보를 담을 SignUpInfo 구조체 구현
  - Data 타입으로의 인코딩을 위한 Encodable 프로토콜 채택

POST 요청에 데이터를 담아 보내기 위한 네트워크 레이어 수정
  - RequestType 프로토콜에 body 추가
  - NetworkService에서 URLRequest를 만들 때, body도 할당하도록 수정

회원가입 요청 정보를 담을 SignUpEndPoint 구조체 구현
  - RequestType 프로토콜을 채택하고 회원가입 요청에 맞게 url, method 설정, body는 생성 시점에 주입받도록 구현함

회원가입 요청, 응답을 처리할 SignUpUseCase 구현
  - 요청 실패 구분을 위한 커스텀 에러 선언
  - 테스트의 용이성을 위해 추상화된 네트워크 레이어를 생성 시점에 주입받도록 구현
  - 회원가입 요청을 보내고, 받아온 응답에 따라 completion 핸들러 실행
  - 성공했다면 completion 핸들러의 인자로 아무것도 보내지 않고, 실패했다면 에러를 담아서 보냄

**요청 -> 응답의 로직만 구현하였고 테스트코드의 작성과 화면과의 연동이 필요합니다.**

#15