### PR TITLE
Model 폴더 충돌 수정

### DIFF
--- a/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
+++ b/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
@@ -78,6 +78,7 @@
 		44E910A1254ACEB1000949A1 /* Model */ = {
 			isa = PBXGroup;
 			children = (
+                B95A6C7B254AD19200D9EC66 /* PatternChecker.swift */,
 				44E910A2254ACEC7000949A1 /* SignUpUseCase.swift */,
 				44E910A8254AD1C7000949A1 /* SignUpEndPoint.swift */,
 				44E910A5254ACF2A000949A1 /* SignUpInfo.swift */,
@@ -128,14 +129,6 @@
 				B95A6C7F254ADA1C00D9EC66 /* String+isNickNamePattern.swift */,
 			);
 			path = Extention;
-			sourceTree = "<group>";
-		};
-		B95A6C7A254AD18500D9EC66 /* Model */ = {
-			isa = PBXGroup;
-			children = (
-				B95A6C7B254AD19200D9EC66 /* PatternChecker.swift */,
-			);
-			path = Model;
 			sourceTree = "<group>";
 		};
 		B980375025484A14002FF4BF = {


### PR DESCRIPTION
두명이 작업한 코드를 merge하는 과정에서 서로 Model 폴더를 만들었는데, 두 폴더의 해시값이 달라 충돌이 발생하였음
git에서 변경사항을 보고 수정하였으나 폴더에 파일이 표시되지 않는 문제 발생
수동으로 project 파일에서 두 폴더를 합쳐줌