### PR TITLE
회원가입 기능에 따른 UI 변화 구현

### DIFF
--- a/iOS/IssueTracker/IssueTracker/Base.lproj/Main.storyboard
+++ b/iOS/IssueTracker/IssueTracker/Base.lproj/Main.storyboard
@@ -206,6 +206,9 @@
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <state key="normal" title="완료"/>
+                                <connections>
+                                    <action selector="completeButtonTouchUp:" destination="pRe-xU-scx" eventType="touchUpInside" id="FIe-Al-Chm"/>
+                                </connections>
                             </button>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="xaJ-CG-YQR"/>

--- a/iOS/IssueTracker/IssueTracker/Common/Extention/UIViewController+Alert.swift
+++ b/iOS/IssueTracker/IssueTracker/Common/Extention/UIViewController+Alert.swift
@@ -9,11 +9,11 @@ import UIKit
 
 extension UIViewController {
     
-    func alert(message: String) {
+    func alert(message: String, completion: @escaping ((UIAlertAction) -> Void) = { _ in }) {
         let alertController = UIAlertController(title: message,
                                                 message: nil,
                                                 preferredStyle: .alert)
-        let okAction = UIAlertAction(title: "OK", style: .cancel, handler: nil)
+        let okAction = UIAlertAction(title: "OK", style: .cancel, handler: completion)
         alertController.addAction(okAction)
         present(alertController, animated: true, completion: nil)
     }

--- a/iOS/IssueTracker/IssueTracker/SignUpScene/Controller/SignUpViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/SignUpScene/Controller/SignUpViewController.swift
@@ -34,6 +34,20 @@ final class SignUpViewController: UIViewController {
         super.viewDidLoad()
         configureInputViews()
     }
+    
+    @IBAction private func completeButtonTouchUp(_ sender: UIButton) {
+        signUpUseCase.signUp(with: patternChecker.info) { [weak self] error in
+            DispatchQueue.main.async {
+                if let error = error {
+                    self?.alert(message: error.localizedDescription)
+                    return
+                }
+                self?.alert(message: "회원가입 성공!", completion: { _ in
+                    self?.navigationController?.popViewController(animated: true)
+                })
+            }
+        }
+    }
 }
 
 extension SignUpViewController: InputViewDelegate {

--- a/iOS/IssueTracker/IssueTracker/SignUpScene/Model/PatternChecker.swift
+++ b/iOS/IssueTracker/IssueTracker/SignUpScene/Model/PatternChecker.swift
@@ -9,33 +9,33 @@ import Foundation
 
 final class PatternChecker {
     
-    private(set) var info: SignUpInfo? = SignUpInfo()
+    private(set) var info: SignUpInfo = SignUpInfo()
     var isComplete: Bool {
-        return isValid(email: info?.email) &&
-            isValid(passWord: info?.password1) &&
-            isValid(passwordCheck: info?.password2) &&
-            isValid(nickName: info?.nickname)
+        return isValid(email: info.email) &&
+            isValid(passWord: info.password) &&
+            isValid(passwordCheck: info.passwordConfirm) &&
+            isValid(nickName: info.nickname)
     }
     
     func isValid(email: String?) -> Bool {
-        info?.email = email
+        info.email = email
         return email?.isEmailPattern() ?? false
     }
     
     func isValid(passWord: String?) -> Bool {
-        info?.password1 = passWord
+        info.password = passWord
         return passWord?.isPasswordPattern() ?? false
     }
     
     func isValid(passwordCheck: String?) -> Bool {
         if let passwordCheck = passwordCheck {
-            info?.password2 = passwordCheck
+            info.passwordConfirm = passwordCheck
         }
-        return info?.password2 == info?.password1
+        return info.passwordConfirm == info.password
     }
     
     func isValid(nickName: String?) -> Bool {
-        info?.nickname = nickName
+        info.nickname = nickName
         return nickName?.isNickNamePattern() ?? false
     }
 }

--- a/iOS/IssueTracker/IssueTracker/SignUpScene/Model/SignUpEndPoint.swift
+++ b/iOS/IssueTracker/IssueTracker/SignUpScene/Model/SignUpEndPoint.swift
@@ -9,7 +9,7 @@ import Foundation
 
 struct SignUpEndPoint: RequestType {
     
-    let url: URL? = URL(string: "api/user/signup")
+    let url: URL? = URL(string: "http://115.85.183.106:3000/api/user/signup")
     let method: RequestMethod = .post
     let body: Data?
 }

--- a/iOS/IssueTracker/IssueTracker/SignUpScene/Model/SignUpInfo.swift
+++ b/iOS/IssueTracker/IssueTracker/SignUpScene/Model/SignUpInfo.swift
@@ -10,7 +10,7 @@ import Foundation
 struct SignUpInfo: Encodable {
     
     var email: String?
-    var password1: String?
-    var password2: String?
+    var password: String?
+    var passwordConfirm: String?
     var nickname: String?
 }

--- a/iOS/IssueTracker/IssueTracker/SignUpScene/Model/SignUpUseCase.swift
+++ b/iOS/IssueTracker/IssueTracker/SignUpScene/Model/SignUpUseCase.swift
@@ -10,6 +10,15 @@ import Foundation
 enum SignUpUseCaseError: Error {
     case encodingError
     case networkError(message: String)
+    
+    var localizedDescription: String {
+        switch self {
+        case .encodingError:
+            return "인코딩 에러"
+        case let .networkError(message):
+            return "회원가입 실패\(message)"
+        }
+    }
 }
 
 protocol SignUpUseCaseType {


### PR DESCRIPTION
SignUpInfo를 변경된 JSON 양식에 맞게 수정
실제 API 주소 적용
회원가입 버튼을 누르면 useCase를 통해 회원가입 요청 후, 응답에 맞게 뷰 변화
성공시, 성공 alert를 띄우고 로그인 화면으로 이동
실패시, 실패 alert를 띄움

#51