### PR TITLE
로그인 기능 테스트코드 작성

### DIFF
--- a/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
+++ b/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		442D5C4025517F2800FB2B2A /* IssueCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 442D5C3E25517F2800FB2B2A /* IssueCollectionViewCell.xib */; };
 		443A9CDA2552B0D0009D3D34 /* IssueListUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 443A9CD92552B0D0009D3D34 /* IssueListUseCase.swift */; };
 		443A9CE22552B179009D3D34 /* IssueListEndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 443A9CE12552B179009D3D34 /* IssueListEndPoint.swift */; };
+		443A9CED2552F89A009D3D34 /* LoginUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 443A9CEC2552F89A009D3D34 /* LoginUseCaseTests.swift */; };
 		447C96F82549745B008D326F /* SignUpViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 447C96F72549745B008D326F /* SignUpViewController.swift */; };
 		4491F599254AEE6B00671C02 /* PatternCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4491F598254AEE6B00671C02 /* PatternCheckerTests.swift */; };
 		44E910A3254ACEC7000949A1 /* SignUpUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44E910A2254ACEC7000949A1 /* SignUpUseCase.swift */; };
@@ -55,6 +56,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		443A9CEF2552F89A009D3D34 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = B980375125484A14002FF4BF /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = B980375825484A14002FF4BF;
+			remoteInfo = IssueTracker;
+		};
 		4491F59B254AEE6B00671C02 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = B980375125484A14002FF4BF /* Project object */;
@@ -81,6 +89,9 @@
 		442D5C3E25517F2800FB2B2A /* IssueCollectionViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = IssueCollectionViewCell.xib; sourceTree = "<group>"; };
 		443A9CD92552B0D0009D3D34 /* IssueListUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueListUseCase.swift; sourceTree = "<group>"; };
 		443A9CE12552B179009D3D34 /* IssueListEndPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueListEndPoint.swift; sourceTree = "<group>"; };
+		443A9CEA2552F89A009D3D34 /* LoginUseCaseTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LoginUseCaseTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		443A9CEC2552F89A009D3D34 /* LoginUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginUseCaseTests.swift; sourceTree = "<group>"; };
+		443A9CEE2552F89A009D3D34 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		447C96F72549745B008D326F /* SignUpViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpViewController.swift; sourceTree = "<group>"; };
 		4491F596254AEE6B00671C02 /* PatternCheckerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PatternCheckerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		4491F598254AEE6B00671C02 /* PatternCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatternCheckerTests.swift; sourceTree = "<group>"; };
@@ -129,6 +140,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		443A9CE72552F89A009D3D34 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		4491F593254AEE6B00671C02 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -162,6 +180,15 @@
 				443A9CE12552B179009D3D34 /* IssueListEndPoint.swift */,
 			);
 			path = Model;
+			sourceTree = "<group>";
+		};
+		443A9CEB2552F89A009D3D34 /* LoginUseCaseTests */ = {
+			isa = PBXGroup;
+			children = (
+				443A9CEC2552F89A009D3D34 /* LoginUseCaseTests.swift */,
+				443A9CEE2552F89A009D3D34 /* Info.plist */,
+			);
+			path = LoginUseCaseTests;
 			sourceTree = "<group>";
 		};
 		447C96F625497449008D326F /* SignUpScene */ = {
@@ -304,6 +331,7 @@
 				B980375B25484A14002FF4BF /* IssueTracker */,
 				B95A6C8A254AE9E800D9EC66 /* SignUpUseCaseTests */,
 				4491F597254AEE6B00671C02 /* PatternCheckerTests */,
+				443A9CEB2552F89A009D3D34 /* LoginUseCaseTests */,
 				B980375A25484A14002FF4BF /* Products */,
 				9E4FCDB20009D47AC3AF8E66 /* Pods */,
 				C0E82A140EF021EEFC5989DB /* Frameworks */,
@@ -316,6 +344,7 @@
 				B980375925484A14002FF4BF /* IssueTracker.app */,
 				B95A6C89254AE9E800D9EC66 /* SignUpUseCaseTests.xctest */,
 				4491F596254AEE6B00671C02 /* PatternCheckerTests.xctest */,
+				443A9CEA2552F89A009D3D34 /* LoginUseCaseTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -393,6 +422,24 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		443A9CE92552F89A009D3D34 /* LoginUseCaseTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 443A9CF12552F89A009D3D34 /* Build configuration list for PBXNativeTarget "LoginUseCaseTests" */;
+			buildPhases = (
+				443A9CE62552F89A009D3D34 /* Sources */,
+				443A9CE72552F89A009D3D34 /* Frameworks */,
+				443A9CE82552F89A009D3D34 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				443A9CF02552F89A009D3D34 /* PBXTargetDependency */,
+			);
+			name = LoginUseCaseTests;
+			productName = LoginUseCaseTests;
+			productReference = 443A9CEA2552F89A009D3D34 /* LoginUseCaseTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		4491F595254AEE6B00671C02 /* PatternCheckerTests */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 4491F59F254AEE6B00671C02 /* Build configuration list for PBXNativeTarget "PatternCheckerTests" */;
@@ -457,6 +504,10 @@
 				LastSwiftUpdateCheck = 1210;
 				LastUpgradeCheck = 1210;
 				TargetAttributes = {
+					443A9CE92552F89A009D3D34 = {
+						CreatedOnToolsVersion = 12.1;
+						TestTargetID = B980375825484A14002FF4BF;
+					};
 					4491F595254AEE6B00671C02 = {
 						CreatedOnToolsVersion = 12.1;
 						TestTargetID = B980375825484A14002FF4BF;
@@ -486,11 +537,19 @@
 				B980375825484A14002FF4BF /* IssueTracker */,
 				B95A6C88254AE9E800D9EC66 /* SignUpUseCaseTests */,
 				4491F595254AEE6B00671C02 /* PatternCheckerTests */,
+				443A9CE92552F89A009D3D34 /* LoginUseCaseTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		443A9CE82552F89A009D3D34 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		4491F594254AEE6B00671C02 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -562,6 +621,14 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		443A9CE62552F89A009D3D34 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				443A9CED2552F89A009D3D34 /* LoginUseCaseTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		4491F592254AEE6B00671C02 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -625,6 +692,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		443A9CF02552F89A009D3D34 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = B980375825484A14002FF4BF /* IssueTracker */;
+			targetProxy = 443A9CEF2552F89A009D3D34 /* PBXContainerItemProxy */;
+		};
 		4491F59C254AEE6B00671C02 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = B980375825484A14002FF4BF /* IssueTracker */;
@@ -657,6 +729,48 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		443A9CF22552F89A009D3D34 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = B3PWYBKFUK;
+				INFOPLIST_FILE = LoginUseCaseTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.1;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.ttozzi.LoginUseCaseTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/IssueTracker.app/IssueTracker";
+			};
+			name = Debug;
+		};
+		443A9CF32552F89A009D3D34 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = B3PWYBKFUK;
+				INFOPLIST_FILE = LoginUseCaseTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.1;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.ttozzi.LoginUseCaseTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/IssueTracker.app/IssueTracker";
+			};
+			name = Release;
+		};
 		4491F59D254AEE6B00671C02 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -898,6 +1012,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		443A9CF12552F89A009D3D34 /* Build configuration list for PBXNativeTarget "LoginUseCaseTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				443A9CF22552F89A009D3D34 /* Debug */,
+				443A9CF32552F89A009D3D34 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		4491F59F254AEE6B00671C02 /* Build configuration list for PBXNativeTarget "PatternCheckerTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/iOS/IssueTracker/LoginUseCaseTests/Info.plist
+++ b/iOS/IssueTracker/LoginUseCaseTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/iOS/IssueTracker/LoginUseCaseTests/LoginUseCaseTests.swift
+++ b/iOS/IssueTracker/LoginUseCaseTests/LoginUseCaseTests.swift
@@ -47,8 +47,8 @@ final class LoginUseCaseTests: XCTestCase {
         let localLoginInfo = LocalLoginInfo(email: "test", password: "test")
         useCase.login(with: localLoginInfo) { result in
             switch result {
-            case .success:
-                XCTFail("서버에서 잘못된 데이터가 왔음에도 성공")
+            case let .success(data):
+                XCTFail("서버에서 잘못된 데이터가 왔음에도 성공 \(data)")
             case let .failure(error):
                 XCTAssertEqual(error, .networkError(message: ""))
             }
@@ -73,8 +73,8 @@ final class LoginUseCaseTests: XCTestCase {
         let appleLoginInfo = AppleLoginInfo(email: "test", name: "test", hashcode: "testtest")
         useCase.login(with: appleLoginInfo) { result in
             switch result {
-            case .success:
-                XCTFail("서버에서 잘못된 데이터가 왔음에도 성공")
+            case let .success(data):
+                XCTFail("서버에서 잘못된 데이터가 왔음에도 성공 \(data)")
             case let .failure(error):
                 XCTAssertEqual(error, .networkError(message: ""))
             }

--- a/iOS/IssueTracker/LoginUseCaseTests/LoginUseCaseTests.swift
+++ b/iOS/IssueTracker/LoginUseCaseTests/LoginUseCaseTests.swift
@@ -1,0 +1,109 @@
+//
+//  LoginUseCaseTests.swift
+//  LoginUseCaseTests
+//
+//  Created by TTOzzi on 2020/11/04.
+//
+
+import XCTest
+@testable import IssueTracker
+
+final class LoginUseCaseTests: XCTestCase {
+    
+    struct MockSuccessNetworkService: NetworkServiceProviding {
+        var userToken: String?
+        
+        func request(requestType: RequestType, completionHandler: @escaping (Result<Data, NetworkError>) -> Void) {
+            let response = LoginResponse(token: "testToken")
+            let data = try? JSONEncoder().encode(response)
+            completionHandler(.success(data!))
+        }
+    }
+    
+    struct MockFailureNetworkService: NetworkServiceProviding {
+        var userToken: String?
+        
+        func request(requestType: RequestType, completionHandler: @escaping (Result<Data, NetworkError>) -> Void) {
+            completionHandler(.failure(.invalidData))
+        }
+        
+    }
+    
+    func testLocalLoginSuccess() {
+        let useCase = LoginUseCase(networkService: MockSuccessNetworkService())
+        let localLoginInfo = LocalLoginInfo(email: "test", password: "test")
+        useCase.login(with: localLoginInfo) { result in
+            switch result {
+            case let .success(response):
+                XCTAssertEqual(response.token, "testToken")
+            case let .failure(error):
+                XCTFail(error.localizedDescription)
+            }
+        }
+    }
+    
+    func testLocalLoginFailure() {
+        let useCase = LoginUseCase(networkService: MockFailureNetworkService())
+        let localLoginInfo = LocalLoginInfo(email: "test", password: "test")
+        useCase.login(with: localLoginInfo) { result in
+            switch result {
+            case .success:
+                XCTFail("서버에서 잘못된 데이터가 왔음에도 성공")
+            case let .failure(error):
+                XCTAssertEqual(error, .networkError(message: ""))
+            }
+        }
+    }
+    
+    func testAppleLoginSuccess() {
+        let useCase = LoginUseCase(networkService: MockSuccessNetworkService())
+        let appleLoginInfo = AppleLoginInfo(email: "test", name: "test", hashcode: "testtest")
+        useCase.login(with: appleLoginInfo) { result in
+            switch result {
+            case let .success(response):
+                XCTAssertEqual(response.token, "testToken")
+            case let .failure(error):
+                XCTFail(error.localizedDescription)
+            }
+        }
+    }
+    
+    func testAppleLoginFailure() {
+        let useCase = LoginUseCase(networkService: MockFailureNetworkService())
+        let appleLoginInfo = AppleLoginInfo(email: "test", name: "test", hashcode: "testtest")
+        useCase.login(with: appleLoginInfo) { result in
+            switch result {
+            case .success:
+                XCTFail("서버에서 잘못된 데이터가 왔음에도 성공")
+            case let .failure(error):
+                XCTAssertEqual(error, .networkError(message: ""))
+            }
+        }
+    }
+}
+
+extension LoginResponse: Encodable {
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(token, forKey: .token)
+    }
+    
+    enum CodingKeys: String, CodingKey {
+        case token
+    }
+}
+
+extension LoginUseCaseError: Equatable {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        switch (lhs, rhs) {
+        case (.decodingError, .decodingError):
+            return true
+        case (.networkError, .networkError):
+            return true
+        case (.encodingError, .encodingError):
+            return true
+        default:
+            return false
+        }
+    }
+}


### PR DESCRIPTION
네트워킹에 성공해 토큰을 completion에 담아 보내는 MockSuccessNetworkService 구현
네트워킹에 실패해 에러를 completion에 담아 보내는 MockFailureNetworkService 구현

LoginResponse를 데이터 타입으로 인코딩 하기 위한 Encodable 채택
LoginUseCaseError간의 비교를 위한 Equatable 채택
두 프로토콜 모두 테스트에만 필요하므로 테스트 코드에 선언

로컬 로그인이 성공하는 경우
로컬 로그인이 실패하는 경우
애플 로그인이 성공하는 경우
애플 로그인이 실패하는 경우 테스트

#111