### PR TITLE
이슈 상세정보 요청 구현

### DIFF
--- a/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
+++ b/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
@@ -31,12 +31,11 @@
 		B9013E5D2554038300B98C10 /* PatternCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9013E5C2554038300B98C10 /* PatternCheckerTests.swift */; };
 		B9013E64255403A600B98C10 /* SignUpUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9013E63255403A600B98C10 /* SignUpUseCaseTests.swift */; };
 		B9013E86255404BA00B98C10 /* MockNetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9013E85255404BA00B98C10 /* MockNetworkService.swift */; };
-		B9013E8F2554055E00B98C10 /* IssueListUseCaseError+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9013E8E2554055E00B98C10 /* IssueListUseCaseError+Equatable.swift */; };
 		B9013E952554057200B98C10 /* Issue+Encodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9013E942554057200B98C10 /* Issue+Encodable.swift */; };
 		B9013E992554059000B98C10 /* MileStone+Encodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9013E982554059000B98C10 /* MileStone+Encodable.swift */; };
 		B9013E9F255405E100B98C10 /* IssueResponse+Encodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9013E9E255405E100B98C10 /* IssueResponse+Encodable.swift */; };
 		B9013EA72554061100B98C10 /* LoginResponse+Encodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9013EA62554061100B98C10 /* LoginResponse+Encodable.swift */; };
-		B9013EAB2554062200B98C10 /* LoginUseCaseError+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9013EAA2554062200B98C10 /* LoginUseCaseError+Equatable.swift */; };
+		B9013EAB2554062200B98C10 /* UseCaseError+Equtable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9013EAA2554062200B98C10 /* UseCaseError+Equtable.swift */; };
 		B9013EAF2554069F00B98C10 /* NetworkServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9013EAE2554069F00B98C10 /* NetworkServiceTests.swift */; };
 		B9013EB325540B2100B98C10 /* NetworkServiceError+Equtable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9013EB225540B2100B98C10 /* NetworkServiceError+Equtable.swift */; };
 		B9013EBE2554227700B98C10 /* IssueDetailPullUpViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9013EBD2554227700B98C10 /* IssueDetailPullUpViewController.swift */; };
@@ -110,12 +109,11 @@
 		B9013E5C2554038300B98C10 /* PatternCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatternCheckerTests.swift; sourceTree = "<group>"; };
 		B9013E63255403A600B98C10 /* SignUpUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpUseCaseTests.swift; sourceTree = "<group>"; };
 		B9013E85255404BA00B98C10 /* MockNetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNetworkService.swift; sourceTree = "<group>"; };
-		B9013E8E2554055E00B98C10 /* IssueListUseCaseError+Equatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "IssueListUseCaseError+Equatable.swift"; sourceTree = "<group>"; };
 		B9013E942554057200B98C10 /* Issue+Encodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Issue+Encodable.swift"; sourceTree = "<group>"; };
 		B9013E982554059000B98C10 /* MileStone+Encodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MileStone+Encodable.swift"; sourceTree = "<group>"; };
 		B9013E9E255405E100B98C10 /* IssueResponse+Encodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "IssueResponse+Encodable.swift"; sourceTree = "<group>"; };
 		B9013EA62554061100B98C10 /* LoginResponse+Encodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LoginResponse+Encodable.swift"; sourceTree = "<group>"; };
-		B9013EAA2554062200B98C10 /* LoginUseCaseError+Equatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LoginUseCaseError+Equatable.swift"; sourceTree = "<group>"; };
+		B9013EAA2554062200B98C10 /* UseCaseError+Equtable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UseCaseError+Equtable.swift"; sourceTree = "<group>"; };
 		B9013EAE2554069F00B98C10 /* NetworkServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkServiceTests.swift; sourceTree = "<group>"; };
 		B9013EB225540B2100B98C10 /* NetworkServiceError+Equtable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NetworkServiceError+Equtable.swift"; sourceTree = "<group>"; };
 		B9013EBD2554227700B98C10 /* IssueDetailPullUpViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueDetailPullUpViewController.swift; sourceTree = "<group>"; };
@@ -246,12 +244,11 @@
 		B9013E8D2554054C00B98C10 /* Extension */ = {
 			isa = PBXGroup;
 			children = (
-				B9013E8E2554055E00B98C10 /* IssueListUseCaseError+Equatable.swift */,
 				B9013E942554057200B98C10 /* Issue+Encodable.swift */,
 				B9013E982554059000B98C10 /* MileStone+Encodable.swift */,
 				B9013E9E255405E100B98C10 /* IssueResponse+Encodable.swift */,
 				B9013EA62554061100B98C10 /* LoginResponse+Encodable.swift */,
-				B9013EAA2554062200B98C10 /* LoginUseCaseError+Equatable.swift */,
+				B9013EAA2554062200B98C10 /* UseCaseError+Equtable.swift */,
 				B9013EB225540B2100B98C10 /* NetworkServiceError+Equtable.swift */,
 			);
 			path = Extension;
@@ -599,7 +596,7 @@
 				B9013E5D2554038300B98C10 /* PatternCheckerTests.swift in Sources */,
 				B9013E64255403A600B98C10 /* SignUpUseCaseTests.swift in Sources */,
 				B9013E86255404BA00B98C10 /* MockNetworkService.swift in Sources */,
-				B9013EAB2554062200B98C10 /* LoginUseCaseError+Equatable.swift in Sources */,
+				B9013EAB2554062200B98C10 /* UseCaseError+Equtable.swift in Sources */,
 				B90C76B025530ABC00134AEE /* IssueListUseCaseTests.swift in Sources */,
 				B9013EB325540B2100B98C10 /* NetworkServiceError+Equtable.swift in Sources */,
 				B9013E9F255405E100B98C10 /* IssueResponse+Encodable.swift in Sources */,
@@ -608,7 +605,6 @@
 				B9013E562554035800B98C10 /* LoginUseCaseTests.swift in Sources */,
 				B9013E952554057200B98C10 /* Issue+Encodable.swift in Sources */,
 				B9013EAF2554069F00B98C10 /* NetworkServiceTests.swift in Sources */,
-				B9013E8F2554055E00B98C10 /* IssueListUseCaseError+Equatable.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
+++ b/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
@@ -14,10 +14,11 @@
 		442D5C3F25517F2800FB2B2A /* IssueCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 442D5C3D25517F2800FB2B2A /* IssueCollectionViewCell.swift */; };
 		442D5C4025517F2800FB2B2A /* IssueCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 442D5C3E25517F2800FB2B2A /* IssueCollectionViewCell.xib */; };
 		443A9CDA2552B0D0009D3D34 /* IssueListUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 443A9CD92552B0D0009D3D34 /* IssueListUseCase.swift */; };
-		443A9CE22552B179009D3D34 /* IssueListEndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 443A9CE12552B179009D3D34 /* IssueListEndPoint.swift */; };
+		443A9CE22552B179009D3D34 /* IssueEndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 443A9CE12552B179009D3D34 /* IssueEndPoint.swift */; };
 		445829AB255422B6003E51E9 /* IssueDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 445829AA255422B6003E51E9 /* IssueDetailViewController.swift */; };
 		445829B3255435B6003E51E9 /* IssueDetailTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 445829B2255435B6003E51E9 /* IssueDetailTableViewCell.swift */; };
 		447C96F82549745B008D326F /* SignUpViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 447C96F72549745B008D326F /* SignUpViewController.swift */; };
+		44ABCDE12558D95F0023457B /* UseCaseError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44ABCDE02558D95F0023457B /* UseCaseError.swift */; };
 		44E910A3254ACEC7000949A1 /* SignUpUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44E910A2254ACEC7000949A1 /* SignUpUseCase.swift */; };
 		44E910A6254ACF2A000949A1 /* SignUpInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44E910A5254ACF2A000949A1 /* SignUpInfo.swift */; };
 		44E910A9254AD1C7000949A1 /* SignUpEndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44E910A8254AD1C7000949A1 /* SignUpEndPoint.swift */; };
@@ -90,10 +91,11 @@
 		442D5C3D25517F2800FB2B2A /* IssueCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueCollectionViewCell.swift; sourceTree = "<group>"; };
 		442D5C3E25517F2800FB2B2A /* IssueCollectionViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = IssueCollectionViewCell.xib; sourceTree = "<group>"; };
 		443A9CD92552B0D0009D3D34 /* IssueListUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueListUseCase.swift; sourceTree = "<group>"; };
-		443A9CE12552B179009D3D34 /* IssueListEndPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueListEndPoint.swift; sourceTree = "<group>"; };
+		443A9CE12552B179009D3D34 /* IssueEndPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueEndPoint.swift; sourceTree = "<group>"; };
 		445829AA255422B6003E51E9 /* IssueDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueDetailViewController.swift; sourceTree = "<group>"; };
 		445829B2255435B6003E51E9 /* IssueDetailTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueDetailTableViewCell.swift; sourceTree = "<group>"; };
 		447C96F72549745B008D326F /* SignUpViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpViewController.swift; sourceTree = "<group>"; };
+		44ABCDE02558D95F0023457B /* UseCaseError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UseCaseError.swift; sourceTree = "<group>"; };
 		44E910A2254ACEC7000949A1 /* SignUpUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpUseCase.swift; sourceTree = "<group>"; };
 		44E910A5254ACF2A000949A1 /* SignUpInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpInfo.swift; sourceTree = "<group>"; };
 		44E910A8254AD1C7000949A1 /* SignUpEndPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpEndPoint.swift; sourceTree = "<group>"; };
@@ -177,7 +179,7 @@
 			children = (
 				442B3DA425525E9300069D18 /* Issue.swift */,
 				443A9CD92552B0D0009D3D34 /* IssueListUseCase.swift */,
-				443A9CE12552B179009D3D34 /* IssueListEndPoint.swift */,
+				443A9CE12552B179009D3D34 /* IssueEndPoint.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -419,6 +421,7 @@
 			isa = PBXGroup;
 			children = (
 				B9BF5A6025499FA60052910D /* NetworkService.swift */,
+				44ABCDE02558D95F0023457B /* UseCaseError.swift */,
 				B95A6C6F254AA86800D9EC66 /* NetworkRequest.swift */,
 			);
 			path = Model;
@@ -641,6 +644,7 @@
 				B949F990254EFB9100477211 /* LoginInfo.swift in Sources */,
 				B9007866255466660035D307 /* ShadowButton.swift in Sources */,
 				B9007862255466510035D307 /* ShadowView.swift in Sources */,
+				44ABCDE12558D95F0023457B /* UseCaseError.swift in Sources */,
 				B980375D25484A14002FF4BF /* AppDelegate.swift in Sources */,
 				B980375F25484A14002FF4BF /* SceneDelegate.swift in Sources */,
 				B90743352551DC3300E1D2E6 /* SettingCoordinator.swift in Sources */,
@@ -654,7 +658,7 @@
 				B98C9C7E254FFB5F002B9CB9 /* NavigationCoordinator.swift in Sources */,
 				B90743022551C4A600E1D2E6 /* LabelListViewController.swift in Sources */,
 				B949F998254F07D900477211 /* LoginUseCase.swift in Sources */,
-				443A9CE22552B179009D3D34 /* IssueListEndPoint.swift in Sources */,
+				443A9CE22552B179009D3D34 /* IssueEndPoint.swift in Sources */,
 				442B3DA525525E9300069D18 /* Issue.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/iOS/IssueTracker/IssueTracker/Base.lproj/Main.storyboard
+++ b/iOS/IssueTracker/IssueTracker/Base.lproj/Main.storyboard
@@ -54,7 +54,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" showsVerticalScrollIndicator="NO" dataMode="prototypes" style="plain" separatorStyle="none" allowsSelection="NO" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="scb-lk-Xcr">
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" showsVerticalScrollIndicator="NO" dataMode="prototypes" style="grouped" separatorStyle="none" allowsSelection="NO" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="1" translatesAutoresizingMaskIntoConstraints="NO" id="scb-lk-Xcr">
                                 <rect key="frame" x="0.0" y="44" width="414" height="818"/>
                                 <color key="backgroundColor" systemColor="systemGroupedBackgroundColor"/>
                                 <view key="tableHeaderView" contentMode="scaleToFill" id="2lH-M5-63d" customClass="IssueInfoView" customModule="IssueTracker" customModuleProvider="target">
@@ -144,7 +144,7 @@
                                 </view>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="IssueDetailTableViewCell" rowHeight="238" id="hDB-z2-GXJ" customClass="IssueDetailTableViewCell" customModule="IssueTracker" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="170" width="414" height="238"/>
+                                        <rect key="frame" x="0.0" y="197.5" width="414" height="238"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="hDB-z2-GXJ" id="qn6-5u-DsE">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="238"/>

--- a/iOS/IssueTracker/IssueTracker/Base.lproj/Main.storyboard
+++ b/iOS/IssueTracker/IssueTracker/Base.lproj/Main.storyboard
@@ -219,7 +219,9 @@
                                         </tableViewCellContentView>
                                         <connections>
                                             <outlet property="contentLabel" destination="TJi-ZD-KBt" id="NSn-J2-Nmd"/>
+                                            <outlet property="creationDateLabel" destination="ycs-yn-6gq" id="4aI-WT-X07"/>
                                             <outlet property="emojiButton" destination="Och-Qj-ugC" id="9qn-kg-Or6"/>
+                                            <outlet property="writerLabel" destination="KsJ-Vx-dEg" id="a92-ET-ddj"/>
                                         </connections>
                                     </tableViewCell>
                                 </prototypes>
@@ -735,7 +737,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="feature" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="8aP-yj-Dpm" customClass="PaddingLabel" customModule="IssueTracker" customModuleProvider="target">
-                                <rect key="frame" x="20" y="359" width="74.5" height="27.5"/>
+                                <rect key="frame" x="20" y="359" width="64.5" height="27.5"/>
                                 <color key="backgroundColor" systemColor="systemTealColor"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="21"/>
                                 <nil key="textColor"/>

--- a/iOS/IssueTracker/IssueTracker/Common/Model/UseCaseError.swift
+++ b/iOS/IssueTracker/IssueTracker/Common/Model/UseCaseError.swift
@@ -1,0 +1,25 @@
+//
+//  UseCaseError.swift
+//  IssueTracker
+//
+//  Created by TTOzzi on 2020/11/09.
+//
+
+import Foundation
+
+enum UseCaseError: Error {
+    case encodingError
+    case decodingError
+    case networkError(message: String)
+    
+    var localizedDescription: String {
+        switch self {
+        case .encodingError:
+            return "인코딩 에러"
+        case .decodingError:
+            return "디코딩 에러"
+        case let .networkError(message):
+            return "네트워크 에러\n\(message)"
+        }
+    }
+}

--- a/iOS/IssueTracker/IssueTracker/Coordinator/IssueCoordinator.swift
+++ b/iOS/IssueTracker/IssueTracker/Coordinator/IssueCoordinator.swift
@@ -17,7 +17,6 @@ final class IssueCoordinator: NavigationCoordinator {
     init(navigationController: UINavigationController, networkService: NetworkServiceProviding) {
         self.navigationController = navigationController
         self.networkService = networkService
-        
     }
     
     func start() {
@@ -33,13 +32,15 @@ final class IssueCoordinator: NavigationCoordinator {
 }
 
 extension IssueCoordinator {
-    func showDetail(of issue: Issue) {
+    func showDetail(of issue: IssueDetail) {
         let pullUpViewController: IssueDetailPullUpViewController =
             storyboard.instantiateViewController(identifier: IssueDetailPullUpViewController.identifier)
         let viewController = storyboard.instantiateViewController(
             identifier: IssueDetailViewController.identifier,
             creator: { coder -> IssueDetailViewController? in
-                return IssueDetailViewController(coder: coder, pullUpViewController: pullUpViewController)
+                return IssueDetailViewController(coder: coder,
+                                                 issue: issue,
+                                                 pullUpViewController: pullUpViewController)
             })
         viewController.coordinator = self
         navigationController?.pushViewController(viewController, animated: true)

--- a/iOS/IssueTracker/IssueTracker/IssueDetailScene/IssueDetailTableViewCell.swift
+++ b/iOS/IssueTracker/IssueTracker/IssueDetailScene/IssueDetailTableViewCell.swift
@@ -12,6 +12,8 @@ final class IssueDetailTableViewCell: UITableViewCell {
     static var identifier: String {
         return String(describing: Self.self)
     }
+    @IBOutlet private weak var writerLabel: UILabel!
+    @IBOutlet private weak var creationDateLabel: UILabel!
     @IBOutlet private weak var contentLabel: UILabel!
     @IBOutlet private weak var emojiButton: UIButton!
     private let topBorder: CALayer = CALayer()
@@ -27,8 +29,11 @@ final class IssueDetailTableViewCell: UITableViewCell {
         configure()
     }
     
-    func update(isComment: Bool) {
+    func update(isComment: Bool, comment: Comment) {
         contentLabel.numberOfLines = isComment ? 2 : 0
+        writerLabel.text = comment.writer
+        creationDateLabel.text = comment.createdAt
+        contentLabel.text = comment.content
     }
 }
 

--- a/iOS/IssueTracker/IssueTracker/IssueDetailScene/IssueDetailViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/IssueDetailScene/IssueDetailViewController.swift
@@ -14,12 +14,14 @@ final class IssueDetailViewController: UIViewController {
     }
     @IBOutlet private weak var issueDetailTableView: UITableView!
     weak var coordinator: IssueCoordinator?
+    private let issue: IssueDetail
     private let pullUpViewController: IssueDetailPullUpViewController
     private let pullUpViewAnimator: UIViewPropertyAnimator = UIViewPropertyAnimator(duration: 0.1,
                                                                                     curve: .easeOut,
                                                                                     animations: nil)
     
-    init?(coder: NSCoder, pullUpViewController: IssueDetailPullUpViewController) {
+    init?(coder: NSCoder, issue: IssueDetail, pullUpViewController: IssueDetailPullUpViewController) {
+        self.issue = issue
         self.pullUpViewController = pullUpViewController
         super.init(coder: coder)
     }
@@ -40,7 +42,6 @@ final class IssueDetailViewController: UIViewController {
         super.viewWillAppear(animated)
         navigationController?.navigationBar.prefersLargeTitles = false
         tabBarController?.tabBar.isHidden = true
-
     }
     
     override func viewWillDisappear(_ animated: Bool) {
@@ -51,7 +52,7 @@ final class IssueDetailViewController: UIViewController {
 
 extension IssueDetailViewController: UITableViewDataSource {
     func numberOfSections(in tableView: UITableView) -> Int {
-        return 10
+        return issue.comments.count
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
@@ -63,7 +64,8 @@ extension IssueDetailViewController: UITableViewDataSource {
                 withIdentifier: IssueDetailTableViewCell.identifier,
                 for: indexPath
         ) as? IssueDetailTableViewCell else { return UITableViewCell() }
-        cell.update(isComment: indexPath.section > 0)
+        let comment = issue.comments[indexPath.section]
+        cell.update(isComment: indexPath.section > 0, comment: comment)
         return cell
     }
 }

--- a/iOS/IssueTracker/IssueTracker/IssueListScene/IssueListViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/IssueListScene/IssueListViewController.swift
@@ -59,7 +59,14 @@ final class IssueListViewController: UIViewController {
 extension IssueListViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         guard let selectedIssue = dataSource?.itemIdentifier(for: indexPath) else { return }
-        coordinator?.showDetail(of: selectedIssue)
+        useCase.loadDetail(with: selectedIssue.id) { [weak self] result in
+            switch result {
+            case let .success(issue):
+                self?.coordinator?.showDetail(of: issue)
+            case let .failure(error):
+                self?.alert(message: error.localizedDescription)
+            }
+        }
     }
 }
 
@@ -122,7 +129,9 @@ private extension IssueListViewController {
             case let .success(issues):
                 self?.issues = issues
             case let .failure(error):
-                break
+                DispatchQueue.main.async {
+                    self?.alert(message: error.localizedDescription)
+                }
             }
         }
     }

--- a/iOS/IssueTracker/IssueTracker/IssueListScene/Model/Issue.swift
+++ b/iOS/IssueTracker/IssueTracker/IssueListScene/Model/Issue.swift
@@ -27,7 +27,32 @@ struct Issue: Decodable, Hashable {
     }
 }
 
+struct Comment: Decodable, Hashable {
+    let writer: String
+    let createdAt: String
+    let content: String
+}
+
 struct MileStone: Decodable, Hashable {
     let id: Int
     let title: String
+}
+
+// 임시 데이터
+struct IssueDetail: Decodable, Hashable {
+    let id: Int
+    let title: String
+    let status: String
+    let mileStone: MileStone?
+    let comments: [Comment]
+    let description: String?
+    
+    enum CodingKeys: String, CodingKey {
+        case id
+        case title
+        case status
+        case comments
+        case mileStone = "milestone"
+        case description
+    }
 }

--- a/iOS/IssueTracker/IssueTracker/IssueListScene/Model/IssueEndPoint.swift
+++ b/iOS/IssueTracker/IssueTracker/IssueListScene/Model/IssueEndPoint.swift
@@ -7,17 +7,20 @@
 
 import Foundation
 
-struct IssueListEndPoint: RequestType {
+struct IssueEndPoint: RequestType {
     
     enum Path: CustomStringConvertible {
         case issues
         case closed(id: Int)
+        case detail(id: Int)
         
         var description: String {
             switch self {
             case .issues:
                 return "/issues"
             case let .closed(id):
+                return "/issues/\(id)"
+            case let .detail(id):
                 return "/issues/\(id)"
             }
         }

--- a/iOS/IssueTracker/IssueTracker/IssueListScene/Model/IssueListUseCase.swift
+++ b/iOS/IssueTracker/IssueTracker/IssueListScene/Model/IssueListUseCase.swift
@@ -7,15 +7,10 @@
 
 import Foundation
 
-enum IssueListUseCaseError: Error {
-    case decodingError
-    case networkError(message: String)
-    case encodingError
-}
-
 protocol IssueListUseCaseType {
-    func loadList(completion: @escaping (Result<[Issue], IssueListUseCaseError>) -> Void)
-    func closeIssue(with id: Int, completion: @escaping (IssueListUseCaseError?) -> Void)
+    func loadList(completion: @escaping (Result<[Issue], UseCaseError>) -> Void)
+    func closeIssue(with id: Int, completion: @escaping (UseCaseError?) -> Void)
+    func loadDetail(with id: Int, completion: @escaping (Result<IssueDetail, UseCaseError>) -> Void)
 }
 
 struct IssueListUseCase: IssueListUseCaseType {
@@ -26,8 +21,8 @@ struct IssueListUseCase: IssueListUseCaseType {
         self.networkService = networkService
     }
     
-    func loadList(completion: @escaping (Result<[Issue], IssueListUseCaseError>) -> Void) {
-        let request = IssueListEndPoint(path: .issues, method: .get)
+    func loadList(completion: @escaping (Result<[Issue], UseCaseError>) -> Void) {
+        let request = IssueEndPoint(path: .issues, method: .get)
         networkService.request(requestType: request) { result in
             switch result {
             case let .success(data):
@@ -42,13 +37,13 @@ struct IssueListUseCase: IssueListUseCaseType {
         }
     }
     
-    func closeIssue(with id: Int, completion: @escaping (IssueListUseCaseError?) -> Void) {
+    func closeIssue(with id: Int, completion: @escaping (UseCaseError?) -> Void) {
         let requestBody = ["status": "closed"]
         guard let data = try? JSONEncoder().encode(requestBody) else {
             completion(.encodingError)
             return
         }
-        let request = IssueListEndPoint(path: .closed(id: id), method: .put, body: data)
+        let request = IssueEndPoint(path: .closed(id: id), method: .put, body: data)
         networkService.request(requestType: request) { result in
             switch result {
             case .success:
@@ -57,5 +52,35 @@ struct IssueListUseCase: IssueListUseCaseType {
                 completion(.networkError(message: error.localizedDescription))
             }
         }
+    }
+    
+    func loadDetail(with id: Int, completion: @escaping (Result<Issue, UseCaseError>) -> Void) {
+        let request = IssueEndPoint(path: .detail(id: id), method: .get)
+        networkService.request(requestType: request) { result in
+            switch result {
+            case let .success(data):
+                guard let issue = try? JSONDecoder().decode(Issue.self, from: data) else {
+                    completion(.failure(.decodingError))
+                    return
+                }
+                completion(.success(issue))
+            case let .failure(error):
+                completion(.failure(.networkError(message: error.localizedDescription)))
+            }
+        }
+    }
+    
+    func loadDetail(with id: Int, completion: @escaping (Result<IssueDetail, UseCaseError>) -> Void) {
+        let issue = IssueDetail(id: 11,
+                          title: "이슈 생성 기능",
+                          status: "Open",
+                          mileStone: nil,
+                          comments: [
+                            Comment(writer: "godrm", createdAt: "16 minutes ago", content: "레이블 전체 목록을 볼 수 있는게 어떨까요\n전체 설명이 보여야 선택할 수 있으니까\n\n마크다운 문법을 지원하고\nHTML형태로 보여줘야 할까요"),
+                            Comment(writer: "crong", createdAt: "16 minutes ago", content: "긍정적인 기능이네요\n댓글은 두줄"),
+                            Comment(writer: "honux", createdAt: "16 minutes ago", content: "굿")
+                          ],
+                          description: nil)
+        completion(.success(issue))
     }
 }

--- a/iOS/IssueTracker/IssueTracker/LoginScene/Model/LoginUseCase.swift
+++ b/iOS/IssueTracker/IssueTracker/LoginScene/Model/LoginUseCase.swift
@@ -7,26 +7,9 @@
 
 import Foundation
 
-enum LoginUseCaseError: Error {
-    case encodingError
-    case networkError(message: String)
-    case decodingError
-    
-    var localizedDescription: String {
-        switch self {
-        case .decodingError:
-            return "디코딩 에러"
-        case let .networkError(message):
-            return "로그인 실패\n\(message)"
-        case .encodingError:
-            return "인코딩 에러"
-        }
-    }
-}
-
 protocol LoginUseCaseType {
-    func login(with info: LocalLoginInfo, completion: @escaping (Result<LoginResponse, LoginUseCaseError>) -> Void)
-    func login(with appleInfo: AppleLoginInfo, completion: @escaping (Result<LoginResponse, LoginUseCaseError>) -> Void)
+    func login(with info: LocalLoginInfo, completion: @escaping (Result<LoginResponse, UseCaseError>) -> Void)
+    func login(with appleInfo: AppleLoginInfo, completion: @escaping (Result<LoginResponse, UseCaseError>) -> Void)
 }
 
 final class LoginUseCase: LoginUseCaseType {
@@ -38,7 +21,7 @@ final class LoginUseCase: LoginUseCaseType {
     }
 
     func login(with localInfo: LocalLoginInfo,
-               completion: @escaping (Result<LoginResponse, LoginUseCaseError>) -> Void) {
+               completion: @escaping (Result<LoginResponse, UseCaseError>) -> Void) {
         guard let data = try? JSONEncoder().encode(localInfo) else {
             completion(.failure(.encodingError))
             return
@@ -59,7 +42,7 @@ final class LoginUseCase: LoginUseCaseType {
     }
     
     func login(with appleInfo: AppleLoginInfo,
-               completion: @escaping (Result<LoginResponse, LoginUseCaseError>) -> Void) {
+               completion: @escaping (Result<LoginResponse, UseCaseError>) -> Void) {
         guard let data = try? JSONEncoder().encode(appleInfo) else {
             completion(.failure(.encodingError))
             return

--- a/iOS/IssueTracker/IssueTracker/SignUpScene/Model/SignUpUseCase.swift
+++ b/iOS/IssueTracker/IssueTracker/SignUpScene/Model/SignUpUseCase.swift
@@ -7,22 +7,8 @@
 
 import Foundation
 
-enum SignUpUseCaseError: Error {
-    case encodingError
-    case networkError(message: String)
-    
-    var localizedDescription: String {
-        switch self {
-        case .encodingError:
-            return "인코딩 에러"
-        case let .networkError(message):
-            return "회원가입 실패\(message)"
-        }
-    }
-}
-
 protocol SignUpUseCaseType {
-    func signUp(with info: SignUpInfo, completion: @escaping (SignUpUseCaseError?) -> Void)
+    func signUp(with info: SignUpInfo, completion: @escaping (UseCaseError?) -> Void)
 }
 
 final class SignUpUseCase: SignUpUseCaseType {
@@ -33,7 +19,7 @@ final class SignUpUseCase: SignUpUseCaseType {
         self.networkService = networkService
     }
     
-    func signUp(with info: SignUpInfo, completion: @escaping (SignUpUseCaseError?) -> Void) {
+    func signUp(with info: SignUpInfo, completion: @escaping (UseCaseError?) -> Void) {
         guard let data = try? JSONEncoder().encode(info) else {
             completion(.encodingError)
             return

--- a/iOS/IssueTracker/IssueTrackerUnitTests/Extension/UseCaseError+Equtable.swift
+++ b/iOS/IssueTracker/IssueTrackerUnitTests/Extension/UseCaseError+Equtable.swift
@@ -8,7 +8,7 @@
 import Foundation
 @testable import IssueTracker
 
-extension LoginUseCaseError: Equatable {
+extension UseCaseError: Equatable {
     public static func == (lhs: Self, rhs: Self) -> Bool {
         switch (lhs, rhs) {
         case (.decodingError, .decodingError):

--- a/iOS/IssueTracker/IssueTrackerUnitTests/NetworkServiceTests.swift
+++ b/iOS/IssueTracker/IssueTrackerUnitTests/NetworkServiceTests.swift
@@ -14,7 +14,7 @@ final class NetworkServiceTests: XCTestCase {
         let expectation = XCTestExpectation(description: "NetworkTaskExpectation")
         defer { wait(for: [expectation], timeout: 5.0)}
         let networkService = NetworkService()
-        let request = IssueListEndPoint(path: .issues, method: .get)
+        let request = IssueEndPoint(path: .issues, method: .get)
         networkService.userToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6NCwiZW1haWwiOiJBQGIuYyIsIm5pY2tuYW1lIjoiQXNkZiIsImlhdCI6MTYwNDQ3ODg2N30.v0ZSPVEW3IyNMVVHPn2mHGUPGw7VeNpMJ3aechf62k4"
         
         networkService.request(requestType: request) { result in
@@ -33,7 +33,7 @@ final class NetworkServiceTests: XCTestCase {
         let expectation = XCTestExpectation(description: "NetworkTaskExpectation")
         defer { wait(for: [expectation], timeout: 5.0)}
         let networkService = NetworkService()
-        let request = IssueListEndPoint(path: .issues, method: .get)
+        let request = IssueEndPoint(path: .issues, method: .get)
         networkService.userToken = "fake"
         networkService.request(requestType: request) { result in
             switch result {


### PR DESCRIPTION
UseCase들의 Error타입들이 대부분 중복되게 선언되어있어 UseCaseError로 통합
셀 선택 이벤트가 발생하면, UseCase를 통해 이슈의 세부 정보를 받아오고, 해당 정보를 coordinator를 통해 이슈 상세화면 뷰 컨트롤러에 주입
이슈 상세화면 뷰 컨트롤러에서는 주입받은 이슈 정보를 화면에 표시
백엔드에서 이슈 코멘트 부분이 구현되어있지 않아 임시 데이터 타입 IssueDetail을 선언해줌(UseCase 메서드도 임시로 데이터를 반환하게만 설정), 기존 데이터 타입인 Issue를 사용하려 했으나 이슈 리스트 화면에선 실제 서버와 통신하기에 디코딩 에러가 발생했음
추후 구현되면 데이터 구조를 맞춰줄 예정

#141 