### PR TITLE
레이블&마일스톤 편집 화면 공통부분 UI 구현

### DIFF
--- a/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
+++ b/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
@@ -14,10 +14,10 @@
 		442D5C3F25517F2800FB2B2A /* IssueCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 442D5C3D25517F2800FB2B2A /* IssueCollectionViewCell.swift */; };
 		442D5C4025517F2800FB2B2A /* IssueCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 442D5C3E25517F2800FB2B2A /* IssueCollectionViewCell.xib */; };
 		443A9CDA2552B0D0009D3D34 /* IssueListUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 443A9CD92552B0D0009D3D34 /* IssueListUseCase.swift */; };
-		443A9CE22552B179009D3D34 /* IssueListEndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 443A9CE12552B179009D3D34 /* IssueListEndPoint.swift */; };
 		443A9CE22552B179009D3D34 /* IssueEndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 443A9CE12552B179009D3D34 /* IssueEndPoint.swift */; };
-		445829AB255422B6003E51E9 /* IssueDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 445829AA255422B6003E51E9 /* IssueDetailViewController.swift */; };
-		445829B3255435B6003E51E9 /* IssueDetailTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 445829B2255435B6003E51E9 /* IssueDetailTableViewCell.swift */; };
+		44791038255A70CB004366B2 /* EditingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44791037255A70CB004366B2 /* EditingViewController.swift */; };
+		4479103C255A7522004366B2 /* EditingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4479103B255A7522004366B2 /* EditingView.swift */; };
+		44791044255A7C2F004366B2 /* AnimatableButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44791043255A7C2F004366B2 /* AnimatableButton.swift */; };
 		447C96F82549745B008D326F /* SignUpViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 447C96F72549745B008D326F /* SignUpViewController.swift */; };
 		449CE3292559332100A56AEB /* IssueCreateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 449CE3282559332100A56AEB /* IssueCreateViewController.swift */; };
 		44ABCDE12558D95F0023457B /* UseCaseError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44ABCDE02558D95F0023457B /* UseCaseError.swift */; };
@@ -96,8 +96,9 @@
 		442D5C3E25517F2800FB2B2A /* IssueCollectionViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = IssueCollectionViewCell.xib; sourceTree = "<group>"; };
 		443A9CD92552B0D0009D3D34 /* IssueListUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueListUseCase.swift; sourceTree = "<group>"; };
 		443A9CE12552B179009D3D34 /* IssueEndPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueEndPoint.swift; sourceTree = "<group>"; };
-		445829AA255422B6003E51E9 /* IssueDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueDetailViewController.swift; sourceTree = "<group>"; };
-		445829B2255435B6003E51E9 /* IssueDetailTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueDetailTableViewCell.swift; sourceTree = "<group>"; };
+		44791037255A70CB004366B2 /* EditingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditingViewController.swift; sourceTree = "<group>"; };
+		4479103B255A7522004366B2 /* EditingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditingView.swift; sourceTree = "<group>"; };
+		44791043255A7C2F004366B2 /* AnimatableButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimatableButton.swift; sourceTree = "<group>"; };
 		447C96F72549745B008D326F /* SignUpViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpViewController.swift; sourceTree = "<group>"; };
 		449CE3282559332100A56AEB /* IssueCreateViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueCreateViewController.swift; sourceTree = "<group>"; };
 		44ABCDE02558D95F0023457B /* UseCaseError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UseCaseError.swift; sourceTree = "<group>"; };
@@ -189,6 +190,15 @@
 				443A9CE12552B179009D3D34 /* IssueEndPoint.swift */,
 			);
 			path = Model;
+			sourceTree = "<group>";
+		};
+		44791036255A70A9004366B2 /* EditingScene */ = {
+			isa = PBXGroup;
+			children = (
+				44791037255A70CB004366B2 /* EditingViewController.swift */,
+				4479103B255A7522004366B2 /* EditingView.swift */,
+			);
+			path = EditingScene;
 			sourceTree = "<group>";
 		};
 		447C96F625497449008D326F /* SignUpScene */ = {
@@ -338,6 +348,7 @@
 				442B3DA9255265B800069D18 /* PaddingLabel.swift */,
 				B9007861255466510035D307 /* ShadowView.swift */,
 				B9007865255466650035D307 /* ShadowButton.swift */,
+				44791043255A7C2F004366B2 /* AnimatableButton.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -401,6 +412,7 @@
 				B9013EBC255421DC00B98C10 /* IssueDetailPullUpScene */,
 				B980375E25484A14002FF4BF /* SceneDelegate.swift */,
 				B91AFB412559387F007AD8DD /* IssueDetailScene */,
+				44791036255A70A9004366B2 /* EditingScene */,
 				B980376225484A14002FF4BF /* Main.storyboard */,
 				B980376525484A16002FF4BF /* Assets.xcassets */,
 				B980376725484A16002FF4BF /* LaunchScreen.storyboard */,
@@ -638,6 +650,7 @@
 				B95A6C78254AD03300D9EC66 /* String+isPasswordPattern.swift in Sources */,
 				B9FBB4FB25518488007207AE /* HomeTabBarCoordinator.swift in Sources */,
 				B95A6C70254AA86800D9EC66 /* NetworkRequest.swift in Sources */,
+				44791044255A7C2F004366B2 /* AnimatableButton.swift in Sources */,
 				B980376125484A14002FF4BF /* LoginViewController.swift in Sources */,
 				442D5C3F25517F2800FB2B2A /* IssueCollectionViewCell.swift in Sources */,
 				443A9CDA2552B0D0009D3D34 /* IssueListUseCase.swift in Sources */,
@@ -645,10 +658,12 @@
 				B95A6C74254ACE9E00D9EC66 /* String+isEmailPattern.swift in Sources */,
 				B9013EBE2554227700B98C10 /* IssueDetailPullUpViewController.swift in Sources */,
 				4403B40D25494B5400503E17 /* InputView.swift in Sources */,
+				44791038255A70CB004366B2 /* EditingViewController.swift in Sources */,
 				442B3DAA255265B800069D18 /* PaddingLabel.swift in Sources */,
 				44E910A6254ACF2A000949A1 /* SignUpInfo.swift in Sources */,
 				B949F990254EFB9100477211 /* LoginInfo.swift in Sources */,
 				B9007866255466660035D307 /* ShadowButton.swift in Sources */,
+				4479103C255A7522004366B2 /* EditingView.swift in Sources */,
 				B9007862255466510035D307 /* ShadowView.swift in Sources */,
 				44ABCDE12558D95F0023457B /* UseCaseError.swift in Sources */,
 				B980375D25484A14002FF4BF /* AppDelegate.swift in Sources */,

--- a/iOS/IssueTracker/IssueTracker/Common/View/AnimatableButton.swift
+++ b/iOS/IssueTracker/IssueTracker/Common/View/AnimatableButton.swift
@@ -23,12 +23,11 @@ class AnimatableButton: UIButton {
     }
     
     private func configure() {
-        self.addTarget(self, action: #selector(animate(_:)), for: .touchUpInside)
-        self.addTarget(self, action: #selector(animate(_:)), for: .touchDown)
-        self.addTarget(self, action: #selector(animate(_:)), for: .touchUpOutside)
+        addTarget(self, action: #selector(animate(_:)), for: .touchUpInside)
+        addTarget(self, action: #selector(animate(_:)), for: .touchDown)
+        addTarget(self, action: #selector(animate(_:)), for: .touchUpOutside)
         titleLabel?.minimumScaleFactor = 0.1
         titleLabel?.adjustsFontSizeToFitWidth = true
-        titleLabel?.lineBreakMode = .byClipping
     }
     
     private func scaleUp(_ sender: UIButton) {

--- a/iOS/IssueTracker/IssueTracker/Common/View/AnimatableButton.swift
+++ b/iOS/IssueTracker/IssueTracker/Common/View/AnimatableButton.swift
@@ -1,0 +1,51 @@
+//
+//  AnimatableButton.swift
+//  IssueTracker
+//
+//  Created by TTOzzi on 2020/11/10.
+//
+
+import UIKit
+
+class AnimatableButton: UIButton {
+    
+    private let animator: UIViewPropertyAnimator = UIViewPropertyAnimator(duration: 0.15, curve: .easeInOut)
+    private var isClicked: Bool = false
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configure()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        configure()
+    }
+    
+    private func configure() {
+        self.addTarget(self, action: #selector(animate(_:)), for: .touchUpInside)
+        self.addTarget(self, action: #selector(animate(_:)), for: .touchDown)
+        self.addTarget(self, action: #selector(animate(_:)), for: .touchUpOutside)
+        titleLabel?.minimumScaleFactor = 0.1
+        titleLabel?.adjustsFontSizeToFitWidth = true
+        titleLabel?.lineBreakMode = .byClipping
+    }
+    
+    private func scaleUp(_ sender: UIButton) {
+        animator.addAnimations {
+            sender.transform = .identity
+        }
+    }
+    
+    private func scaleDown(_ sender: UIButton) {
+        animator.addAnimations {
+            sender.transform = CGAffineTransform(scaleX: 0.94, y: 0.94)
+        }
+    }
+    
+    @objc private func animate(_ sender: UIButton) {
+        isClicked.toggle()
+        isClicked ? scaleDown(sender) : scaleUp(sender)
+        animator.startAnimation()
+    }
+}

--- a/iOS/IssueTracker/IssueTracker/Common/View/ShadowButton.swift
+++ b/iOS/IssueTracker/IssueTracker/Common/View/ShadowButton.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 @IBDesignable
-final class ShadowButton: UIButton {
+final class ShadowButton: AnimatableButton {
 
     @IBInspectable private var cornerRadius: CGFloat {
         get { layer.cornerRadius }

--- a/iOS/IssueTracker/IssueTracker/EditingScene/EditingView.swift
+++ b/iOS/IssueTracker/IssueTracker/EditingScene/EditingView.swift
@@ -1,0 +1,135 @@
+//
+//  EditingView.swift
+//  IssueTracker
+//
+//  Created by TTOzzi on 2020/11/10.
+//
+
+import UIKit
+
+protocol EditingViewDelegate: class {
+    func closeButtonDidTouchUp(_ editingView: EditingView)
+    func resetButtonDidTouchUp(_ editingView: EditingView)
+    func saveButtonDidTouchUp(_ editingView: EditingView)
+}
+
+final class EditingView: UIView {
+    
+    private let closeButton: AnimatableButton = {
+        let button = AnimatableButton()
+        let image = UIImage(systemName: "xmark",
+                            withConfiguration: UIImage.SymbolConfiguration(pointSize: 18, weight: .semibold))
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.setImage(image, for: .normal)
+        button.tintColor = .black
+        button.addTarget(self, action: #selector(closeButtonDidTouchUp), for: .touchUpInside)
+        return button
+    }()
+    private let borderView: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.backgroundColor = .opaqueSeparator
+        return view
+    }()
+    private let resetButton: UIButton = {
+        let button = UIButton()
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.setTitle("초기화", for: .normal)
+        button.setTitleColor(.systemGray, for: .normal)
+        button.setTitleColor(button.currentTitleColor.withAlphaComponent(0.3), for: .highlighted)
+        button.titleLabel?.font = .boldSystemFont(ofSize: 14)
+        button.addTarget(self, action: #selector(resetButtonDidTouchUp), for: .touchUpInside)
+        return button
+    }()
+    private let saveButton: AnimatableButton = {
+        let button = AnimatableButton()
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.setTitle("저장", for: .normal)
+        button.setTitleColor(.systemBackground, for: .normal)
+        button.backgroundColor = .label
+        button.layer.cornerRadius = 10
+        button.addTarget(self, action: #selector(saveButtonDidTouchUp), for: .touchUpInside)
+        return button
+    }()
+    weak var delegate: EditingViewDelegate?
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        configure()
+    }
+    
+    func addContentView(_ contentView: UIView) {
+        contentView.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(contentView)
+        NSLayoutConstraint.activate([
+            contentView.topAnchor.constraint(equalTo: borderView.bottomAnchor),
+            contentView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            contentView.bottomAnchor.constraint(equalTo: saveButton.topAnchor, constant: -16),
+            contentView.trailingAnchor.constraint(equalTo: trailingAnchor)
+        ])
+    }
+    
+    @objc private func closeButtonDidTouchUp() {
+        delegate?.closeButtonDidTouchUp(self)
+    }
+    
+    @objc private func resetButtonDidTouchUp() {
+        delegate?.resetButtonDidTouchUp(self)
+    }
+    
+    @objc private func saveButtonDidTouchUp() {
+        delegate?.saveButtonDidTouchUp(self)
+    }
+}
+
+private extension EditingView {
+    func configure() {
+        layer.cornerRadius = 10
+        backgroundColor = .systemBackground
+        configureCloseButton()
+        configureBorderView()
+        configureResetButton()
+        configureSaveButton()
+    }
+    
+    func configureCloseButton() {
+        addSubview(closeButton)
+        NSLayoutConstraint.activate([
+            closeButton.topAnchor.constraint(equalTo: topAnchor, constant: 8),
+            closeButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+            closeButton.widthAnchor.constraint(equalToConstant: 44),
+            closeButton.heightAnchor.constraint(equalToConstant: 44)
+        ])
+    }
+    
+    func configureBorderView() {
+        addSubview(borderView)
+        NSLayoutConstraint.activate([
+            borderView.topAnchor.constraint(equalTo: closeButton.bottomAnchor, constant: 8),
+            borderView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            borderView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            borderView.heightAnchor.constraint(equalToConstant: 1.5)
+        ])
+    }
+    
+    func configureResetButton() {
+        addSubview(resetButton)
+        NSLayoutConstraint.activate([
+            resetButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+            resetButton.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -8),
+            resetButton.widthAnchor.constraint(equalToConstant: 60),
+            resetButton.heightAnchor.constraint(equalToConstant: 44)
+        ])
+    }
+    
+    func configureSaveButton() {
+        addSubview(saveButton)
+        NSLayoutConstraint.activate([
+            saveButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
+            saveButton.bottomAnchor.constraint(lessThanOrEqualTo: bottomAnchor, constant: -8),
+            saveButton.centerYAnchor.constraint(equalTo: resetButton.centerYAnchor),
+            saveButton.widthAnchor.constraint(equalToConstant: 72),
+            saveButton.heightAnchor.constraint(equalToConstant: 44)
+        ])
+    }
+}

--- a/iOS/IssueTracker/IssueTracker/EditingScene/EditingViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/EditingScene/EditingViewController.swift
@@ -1,0 +1,78 @@
+//
+//  EditingViewController.swift
+//  IssueTracker
+//
+//  Created by TTOzzi on 2020/11/10.
+//
+
+import UIKit
+
+class EditingViewController: UIViewController {
+    
+    private let backgroundView: UIView = UIView()
+    private let editingView: EditingView = EditingView()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        editingView.delegate = self
+        configure()
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        UIViewPropertyAnimator(duration: 0.25, curve: .linear) { [weak self] in
+            self?.backgroundView.alpha = 0.3
+        }.startAnimation()
+    }
+}
+
+extension EditingViewController: EditingViewDelegate {
+    func closeButtonDidTouchUp(_ editingView: EditingView) {
+        dismissWithAnimation()
+    }
+    
+    func resetButtonDidTouchUp(_ editingView: EditingView) {
+        
+    }
+    
+    func saveButtonDidTouchUp(_ editingView: EditingView) {
+        dismissWithAnimation()
+    }
+}
+
+private extension EditingViewController {
+    func configure() {
+        configureBackgroundView()
+        configureEditingView()
+    }
+    
+    func configureBackgroundView() {
+        backgroundView.backgroundColor = .black
+        backgroundView.alpha = 0
+        backgroundView.frame = view.frame
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(dismissWithAnimation))
+        backgroundView.addGestureRecognizer(tapGesture)
+        view.insertSubview(backgroundView, at: 0)
+    }
+    
+    func configureEditingView() {
+        editingView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(editingView)
+        NSLayoutConstraint.activate([
+            editingView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            editingView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            editingView.heightAnchor.constraint(equalTo: view.heightAnchor, multiplier: 0.5),
+            editingView.widthAnchor.constraint(equalTo: view.widthAnchor, multiplier: 0.9)
+        ])
+    }
+    
+    @objc func dismissWithAnimation() {
+        let animator = UIViewPropertyAnimator(duration: 0.25, curve: .linear) { [weak self] in
+            self?.backgroundView.alpha = 0
+        }
+        animator.addCompletion { [weak self] _ in
+            self?.dismiss(animated: true)
+        }
+        animator.startAnimation()
+    }
+}

--- a/iOS/IssueTracker/IssueTracker/LoginScene/Controller/LoginViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/LoginScene/Controller/LoginViewController.swift
@@ -116,7 +116,7 @@ extension LoginViewController: ASAuthorizationControllerDelegate {
     }
     
     func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
-        print(error)
+        alert(message: "로그인 실패!\n\(error.localizedDescription)")
     }
 }
 


### PR DESCRIPTION
버튼에 애니메이션을 주기 위해 AnimatableButton 커스텀 클래스 구현
스케일값을 조절해 버튼이 눌리는 애니메이션 구현

편집 화면을 관리할 EditingViewController 구현
뒷배경을 불투명하게 표시하기위한 backgroundView 구현
처음부터 불투명한 채로 modal을 띄우면 불투명한 화면이 올라오는게 보여서 뷰가 나타난 다음 불투명하게 바뀌도록 애니메이션 구현
x 버튼, 저장 버튼을 누르면 dismiss
backgroundView에 tapGesture를 추가하여 editingView 바깥 영역을 터치하면 dismiss
화면을 dismiss할 때도 자연스럽게 내려가게하기위해 불투명한 배경을 먼저 투명하게 하고 dismiss

편집 화면을 EditingView 커스텀 클래스를 만들어 구현
재사용을 위해 모든 UI를 코드로 구현
버튼 이벤트를 뷰 컨트롤러로 전달하기 위한 delegate 구현
공통 부분을 제외한 레이블, 마일스톤의 다른 화면을 추가하기 위한 addContentView 메서드 구현

색칠된 영역이 교체될 콘텐츠 뷰 영역입니다.
<img width="40%" alt="스크린샷 2020-11-10 오후 6 10 12" src="https://user-images.githubusercontent.com/50410213/98654505-c0f58000-2381-11eb-8d16-16e62efec927.png">

화면을 보여주기 위해 임시로 + 버튼을 누르면 띄워지게 설정하였습니다. 커밋한 코드에는 반영되어있지 않습니다.
<img width="40%" src="https://user-images.githubusercontent.com/50410213/98654586-d9659a80-2381-11eb-8f75-025a4f99fdd9.gif">

#160