### PR TITLE
레이블 관리 화면 UI 구현

### DIFF
--- a/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
+++ b/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
@@ -18,6 +18,8 @@
 		44791038255A70CB004366B2 /* EditingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44791037255A70CB004366B2 /* EditingViewController.swift */; };
 		4479103C255A7522004366B2 /* EditingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4479103B255A7522004366B2 /* EditingView.swift */; };
 		44791044255A7C2F004366B2 /* AnimatableButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44791043255A7C2F004366B2 /* AnimatableButton.swift */; };
+		44791048255AB7CE004366B2 /* Label.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44791047255AB7CE004366B2 /* Label.swift */; };
+		4479104C255AB80A004366B2 /* LabelCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4479104B255AB80A004366B2 /* LabelCollectionViewCell.swift */; };
 		447C96F82549745B008D326F /* SignUpViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 447C96F72549745B008D326F /* SignUpViewController.swift */; };
 		449CE3292559332100A56AEB /* IssueCreateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 449CE3282559332100A56AEB /* IssueCreateViewController.swift */; };
 		44ABCDE12558D95F0023457B /* UseCaseError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44ABCDE02558D95F0023457B /* UseCaseError.swift */; };
@@ -99,6 +101,8 @@
 		44791037255A70CB004366B2 /* EditingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditingViewController.swift; sourceTree = "<group>"; };
 		4479103B255A7522004366B2 /* EditingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditingView.swift; sourceTree = "<group>"; };
 		44791043255A7C2F004366B2 /* AnimatableButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimatableButton.swift; sourceTree = "<group>"; };
+		44791047255AB7CE004366B2 /* Label.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Label.swift; sourceTree = "<group>"; };
+		4479104B255AB80A004366B2 /* LabelCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelCollectionViewCell.swift; sourceTree = "<group>"; };
 		447C96F72549745B008D326F /* SignUpViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpViewController.swift; sourceTree = "<group>"; };
 		449CE3282559332100A56AEB /* IssueCreateViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueCreateViewController.swift; sourceTree = "<group>"; };
 		44ABCDE02558D95F0023457B /* UseCaseError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UseCaseError.swift; sourceTree = "<group>"; };
@@ -277,6 +281,8 @@
 			isa = PBXGroup;
 			children = (
 				B90743012551C4A600E1D2E6 /* LabelListViewController.swift */,
+				4479104B255AB80A004366B2 /* LabelCollectionViewCell.swift */,
+				44791047255AB7CE004366B2 /* Label.swift */,
 			);
 			path = LabelListScene;
 			sourceTree = "<group>";
@@ -643,6 +649,7 @@
 				B98C9C79254FDC99002B9CB9 /* LoginResponse.swift in Sources */,
 				B90743282551DB9A00E1D2E6 /* SettingViewController.swift in Sources */,
 				449CE3292559332100A56AEB /* IssueCreateViewController.swift in Sources */,
+				44791048255AB7CE004366B2 /* Label.swift in Sources */,
 				44EA5D95255032A8008AB0EB /* IssueListViewController.swift in Sources */,
 				B907430A2551C5E400E1D2E6 /* LabelCoordinator.swift in Sources */,
 				B9FBB4EB25517D66007207AE /* TabBarCoordinator.swift in Sources */,
@@ -679,6 +686,7 @@
 				B90743302551DC2C00E1D2E6 /* MileStoneCoordinator.swift in Sources */,
 				B98C9C7E254FFB5F002B9CB9 /* NavigationCoordinator.swift in Sources */,
 				B90743022551C4A600E1D2E6 /* LabelListViewController.swift in Sources */,
+				4479104C255AB80A004366B2 /* LabelCollectionViewCell.swift in Sources */,
 				B91AFB4B255938B6007AD8DD /* IssueDetailTableViewCell.swift in Sources */,
 				B949F998254F07D900477211 /* LoginUseCase.swift in Sources */,
 				B91AFB5125594085007AD8DD /* IssueListViewEditTabBar.swift in Sources */,

--- a/iOS/IssueTracker/IssueTracker/Base.lproj/Main.storyboard
+++ b/iOS/IssueTracker/IssueTracker/Base.lproj/Main.storyboard
@@ -607,19 +607,64 @@
                                 <rect key="frame" x="0.0" y="44" width="414" height="818"/>
                                 <color key="backgroundColor" systemColor="systemGray6Color"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="QMu-sG-FB2">
-                                    <size key="itemSize" width="128" height="128"/>
+                                    <size key="itemSize" width="414" height="56"/>
                                     <size key="headerReferenceSize" width="0.0" height="0.0"/>
                                     <size key="footerReferenceSize" width="0.0" height="0.0"/>
                                     <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                 </collectionViewFlowLayout>
                                 <cells>
-                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="B3P-aM-588">
-                                        <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
+                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="LabelCollectionViewCell" id="B3P-aM-588" customClass="LabelCollectionViewCell" customModule="IssueTracker" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="56"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="hyp-Fp-Xub">
-                                            <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="56"/>
                                             <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="6le-0o-I1g">
+                                                    <rect key="frame" x="16" y="8" width="155" height="40"/>
+                                                    <subviews>
+                                                        <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="500" text="feature" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hr9-ne-Ry6" customClass="PaddingLabel" customModule="IssueTracker" customModuleProvider="target">
+                                                            <rect key="frame" x="0.0" y="0.0" width="56" height="19"/>
+                                                            <color key="backgroundColor" systemColor="systemTealColor"/>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                            <nil key="textColor"/>
+                                                            <nil key="highlightedColor"/>
+                                                            <userDefinedRuntimeAttributes>
+                                                                <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                                                    <real key="value" value="5"/>
+                                                                </userDefinedRuntimeAttribute>
+                                                                <userDefinedRuntimeAttribute type="number" keyPath="paddingWidth">
+                                                                    <real key="value" value="10"/>
+                                                                </userDefinedRuntimeAttribute>
+                                                                <userDefinedRuntimeAttribute type="number" keyPath="paddingHeight">
+                                                                    <real key="value" value="2"/>
+                                                                </userDefinedRuntimeAttribute>
+                                                            </userDefinedRuntimeAttributes>
+                                                        </label>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="500" text="기능에 대한 레이블입니다." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PLX-3F-xVU">
+                                                            <rect key="frame" x="0.0" y="25" width="155" height="15"/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="15" id="4Vn-VH-XMo"/>
+                                                            </constraints>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                                            <color key="textColor" systemColor="systemGrayColor"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                    </subviews>
+                                                </stackView>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="6le-0o-I1g" firstAttribute="leading" secondItem="hyp-Fp-Xub" secondAttribute="leading" constant="16" id="9zd-lb-COR"/>
+                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="6le-0o-I1g" secondAttribute="trailing" constant="32" id="V8k-fX-XUD"/>
+                                                <constraint firstAttribute="bottom" secondItem="6le-0o-I1g" secondAttribute="bottom" constant="8" id="YNS-Be-39C"/>
+                                                <constraint firstItem="6le-0o-I1g" firstAttribute="top" secondItem="hyp-Fp-Xub" secondAttribute="top" constant="8" id="bXZ-oj-tbT"/>
+                                            </constraints>
                                         </collectionViewCellContentView>
+                                        <size key="customSize" width="414" height="56"/>
+                                        <connections>
+                                            <outlet property="descriptionLabel" destination="PLX-3F-xVU" id="m1f-W1-Voq"/>
+                                            <outlet property="labelLabel" destination="hr9-ne-Ry6" id="tkb-om-6Gq"/>
+                                        </connections>
                                     </collectionViewCell>
                                 </cells>
                             </collectionView>
@@ -633,10 +678,13 @@
                             <constraint firstItem="ebC-Bw-szy" firstAttribute="top" secondItem="RcB-1O-PKH" secondAttribute="top" id="itS-e1-oks"/>
                         </constraints>
                     </view>
+                    <connections>
+                        <outlet property="labelCollectionView" destination="ebC-Bw-szy" id="Gax-J5-KNt"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="0jU-mA-C6D" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="378" y="500"/>
+            <point key="canvasLocation" x="376.81159420289856" y="1301.7857142857142"/>
         </scene>
         <!--Mile Stone List View Controller-->
         <scene sceneID="0P1-yV-N2K">
@@ -877,7 +925,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="feature" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="8aP-yj-Dpm" customClass="PaddingLabel" customModule="IssueTracker" customModuleProvider="target">
-                                <rect key="frame" x="20" y="359" width="64.5" height="27.5"/>
+                                <rect key="frame" x="20" y="359" width="74.5" height="27.5"/>
                                 <color key="backgroundColor" systemColor="systemTealColor"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="21"/>
                                 <nil key="textColor"/>
@@ -1060,10 +1108,13 @@
             <size key="intrinsicContentSize" width="94" height="33"/>
         </designable>
         <designable name="8aP-yj-Dpm">
-            <size key="intrinsicContentSize" width="64.5" height="25.5"/>
+            <size key="intrinsicContentSize" width="74.5" height="27.5"/>
         </designable>
         <designable name="ZCV-7a-4VR">
             <size key="intrinsicContentSize" width="56" height="30"/>
+        </designable>
+        <designable name="hr9-ne-Ry6">
+            <size key="intrinsicContentSize" width="56" height="19"/>
         </designable>
         <designable name="k3Y-fo-ljF">
             <size key="intrinsicContentSize" width="17" height="22"/>

--- a/iOS/IssueTracker/IssueTracker/Coordinator/LabelCoordinator.swift
+++ b/iOS/IssueTracker/IssueTracker/Coordinator/LabelCoordinator.swift
@@ -27,3 +27,11 @@ final class LabelCoordinator: NavigationCoordinator {
         navigationController?.pushViewController(viewContoller, animated: true)
     }
 }
+
+extension LabelCoordinator {
+    func showEdit() {
+        let editingViewController = EditingViewController()
+        editingViewController.modalPresentationStyle = .overFullScreen
+        navigationController?.present(editingViewController, animated: true)
+    }
+}

--- a/iOS/IssueTracker/IssueTracker/IssueListScene/IssueListViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/IssueListScene/IssueListViewController.swift
@@ -24,7 +24,6 @@ final class IssueListViewController: UIViewController {
     @IBOutlet private weak var issueCollectionView: UICollectionView!
     weak var coordinator: IssueCoordinator?
     private let useCase: IssueListUseCaseType
-    private var dataSource: IssueCollectionViewDataSource?
     private var issueListViewEditTabBar: IssueListViewEditTabBar!
     private var selectedCellsCount: Int =  0 {
         didSet {
@@ -37,6 +36,7 @@ final class IssueListViewController: UIViewController {
             updateList()
         }
     }
+    private lazy var dataSource: IssueCollectionViewDataSource = issueDataSource()
     
     init?(coder: NSCoder, useCase: IssueListUseCaseType) {
         self.useCase = useCase
@@ -83,7 +83,7 @@ final class IssueListViewController: UIViewController {
 extension IssueListViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         if !isEditing {
-            guard let selectedIssue = dataSource?.itemIdentifier(for: indexPath) else { return }
+            guard let selectedIssue = dataSource.itemIdentifier(for: indexPath) else { return }
             useCase.loadDetail(with: selectedIssue.id) { [weak self] result in
                 switch result {
                 case let .success(issue):
@@ -151,7 +151,7 @@ private extension IssueListViewController {
         snapshot.appendSections([.main])
         snapshot.appendItems(issues, toSection: .main)
         DispatchQueue.main.async { [weak self] in
-            self?.dataSource?.apply(snapshot)
+            self?.dataSource.apply(snapshot)
         }
     }
 }
@@ -235,7 +235,6 @@ private extension IssueListViewController {
     func configureCollectionView() {
         let cellNib = UINib(nibName: IssueCollectionViewCell.identifier, bundle: .main)
         issueCollectionView.register(cellNib, forCellWithReuseIdentifier: IssueCollectionViewCell.identifier)
-        dataSource = issueDataSource()
         issueCollectionView.dataSource = dataSource
         issueCollectionView.delegate = self
         issueCollectionView.setCollectionViewLayout(issueCollectionViewLayout(), animated: true)

--- a/iOS/IssueTracker/IssueTracker/LabelListScene/Label.swift
+++ b/iOS/IssueTracker/IssueTracker/LabelListScene/Label.swift
@@ -1,0 +1,15 @@
+//
+//  Label.swift
+//  IssueTracker
+//
+//  Created by TTOzzi on 2020/11/10.
+//
+
+import Foundation
+
+struct Label: Hashable {
+    let id: Int
+    let title: String
+    let color: String
+    let description: String?
+}

--- a/iOS/IssueTracker/IssueTracker/LabelListScene/LabelCollectionViewCell.swift
+++ b/iOS/IssueTracker/IssueTracker/LabelListScene/LabelCollectionViewCell.swift
@@ -1,0 +1,38 @@
+//
+//  LabelCollectionViewCell.swift
+//  IssueTracker
+//
+//  Created by TTOzzi on 2020/11/10.
+//
+
+import UIKit
+
+final class LabelCollectionViewCell: UICollectionViewListCell {
+    
+    static var identifier: String {
+        return String(describing: Self.self)
+    }
+    @IBOutlet private weak var labelLabel: PaddingLabel!
+    @IBOutlet private weak var descriptionLabel: UILabel!
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configure()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        configure()
+    }
+    
+    func update(with label: Label) {
+        labelLabel.text = label.title
+        descriptionLabel.text = label.description
+    }
+}
+
+private extension LabelCollectionViewCell {
+    func configure() {
+        accessories = [.disclosureIndicator()]
+    }
+}

--- a/iOS/IssueTracker/IssueTracker/LabelListScene/LabelListViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/LabelListScene/LabelListViewController.swift
@@ -12,13 +12,89 @@ final class LabelListViewController: UIViewController {
     static var identifier: String {
         return String(describing: Self.self)
     }
+    @IBOutlet private weak var labelCollectionView: UICollectionView!
     weak var coordinator: LabelCoordinator?
+    private var labels: [Label] = [
+        Label(id: 1, title: "hello", color: "", description: "asdf"),
+        Label(id: 2, title: "asdf", color: "", description: "vzxcvz"),
+        Label(id: 3, title: "afewfwa", color: "", description: "asdfasdfasdf"),
+        Label(id: 4, title: "ff", color: "", description: nil)
+    ] {
+        didSet {
+            updateList()
+        }
+    }
+    private lazy var dataSource: LabelCollectionViewDataSource = labelDataSource()
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        configure()
+        updateList()
+    }
+}
 
-        navigationItem.rightBarButtonItem = UIBarButtonItem(systemItem: .add)
+private extension LabelListViewController {
+    @objc func addButtonDidTouchUp() {
+        coordinator?.showEdit()
+    }
+}
+
+private extension LabelListViewController {
+    func labelCollectionViewLayout() -> UICollectionViewCompositionalLayout {
+        let configuration = UICollectionLayoutListConfiguration(appearance: .plain)
+        return UICollectionViewCompositionalLayout.list(using: configuration)
+    }
+}
+
+private extension LabelListViewController {
+    enum Section {
+        case main
+    }
+    
+    typealias LabelCollectionViewDataSource = UICollectionViewDiffableDataSource<Section, Label>
+    typealias LabelCollectionViewSnapshot = NSDiffableDataSourceSnapshot<Section, Label>
+    
+    func labelDataSource() -> LabelCollectionViewDataSource {
+        return LabelCollectionViewDataSource(
+            collectionView: labelCollectionView,
+            cellProvider: { collectionView, indexPath, label -> LabelCollectionViewCell? in
+                let cell = collectionView.dequeueReusableCell(
+                    withReuseIdentifier: LabelCollectionViewCell.identifier,
+                    for: indexPath
+                ) as? LabelCollectionViewCell
+                cell?.update(with: label)
+                return cell
+            }
+        )
+    }
+    
+    func updateList() {
+        var snapshot = LabelCollectionViewSnapshot()
+        snapshot.appendSections([.main])
+        snapshot.appendItems(labels, toSection: .main)
+        DispatchQueue.main.async { [weak self] in
+            self?.dataSource.apply(snapshot)
+        }
+    }
+}
+
+private extension LabelListViewController {
+    func configure() {
+        configureNavigationBar()
+        configureCollectionView()
+    }
+    
+    func configureNavigationBar() {
+        navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .add,
+                                                            target: self,
+                                                            action: #selector(addButtonDidTouchUp))
         navigationController?.navigationBar.prefersLargeTitles = true
         navigationController?.navigationBar.topItem?.title = "레이블"
+    }
+    
+    func configureCollectionView() {
+        labelCollectionView.dataSource = dataSource
+        labelCollectionView.setCollectionViewLayout(labelCollectionViewLayout(), animated: true)
+        labelCollectionView.allowsSelection = false
     }
 }


### PR DESCRIPTION
레이블 데이터를 나타낼 Label 구조체 구현, DiffableDataSource 적용을 위한 Hashable 채택
레이블을 표시할 커스텀 셀 구현, accessories 표시를 위해 UICollectionViewListCell 상속
UICollectionViewCompositionalLayout을 활용한 리스트 형태의 UI 구현
UICollectionViewDiffableDataSource 적용

API 통신 없이 임시 데이터를 활용해 화면을 표시해주었습니다.
<img width="40%" alt="스크린샷 2020-11-10 오후 9 27 17" src="https://user-images.githubusercontent.com/50410213/98675108-27d46280-239d-11eb-82e8-b9e50e913464.png">


#161