### PR TITLE
레이블 관련 기능 연동

### DIFF
--- a/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
+++ b/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		442D5C4025517F2800FB2B2A /* IssueCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 442D5C3E25517F2800FB2B2A /* IssueCollectionViewCell.xib */; };
 		443A9CDA2552B0D0009D3D34 /* IssueListUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 443A9CD92552B0D0009D3D34 /* IssueListUseCase.swift */; };
 		443A9CE22552B179009D3D34 /* IssueEndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 443A9CE12552B179009D3D34 /* IssueEndPoint.swift */; };
+		444C9A3F255C6CAA0098C437 /* LabelUseCaseType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 444C9A3E255C6CAA0098C437 /* LabelUseCaseType.swift */; };
 		44791038255A70CB004366B2 /* DimmedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44791037255A70CB004366B2 /* DimmedViewController.swift */; };
 		4479103C255A7522004366B2 /* EditingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4479103B255A7522004366B2 /* EditingView.swift */; };
 		44791044255A7C2F004366B2 /* AnimatableButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44791043255A7C2F004366B2 /* AnimatableButton.swift */; };
@@ -74,7 +75,7 @@
 		B96FDAE5255C03CC00A1251C /* UIColor+hex.swift in Sources */ = {isa = PBXBuildFile; fileRef = B96FDAE4255C03CC00A1251C /* UIColor+hex.swift */; };
 		B96FDAEA255C0E7700A1251C /* LabelListUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B96FDAE9255C0E7700A1251C /* LabelListUseCase.swift */; };
 		B96FDAF0255C0E8200A1251C /* LabelEndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = B96FDAEF255C0E8200A1251C /* LabelEndPoint.swift */; };
-		B96FDAF4255C107C00A1251C /* LabelResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = B96FDAF3255C107C00A1251C /* LabelResponse.swift */; };
+		B96FDAF4255C107C00A1251C /* LabelListResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = B96FDAF3255C107C00A1251C /* LabelListResponse.swift */; };
 		B980375D25484A14002FF4BF /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B980375C25484A14002FF4BF /* AppDelegate.swift */; };
 		B980375F25484A14002FF4BF /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B980375E25484A14002FF4BF /* SceneDelegate.swift */; };
 		B980376125484A14002FF4BF /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B980376025484A14002FF4BF /* LoginViewController.swift */; };
@@ -110,6 +111,7 @@
 		442D5C3E25517F2800FB2B2A /* IssueCollectionViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = IssueCollectionViewCell.xib; sourceTree = "<group>"; };
 		443A9CD92552B0D0009D3D34 /* IssueListUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueListUseCase.swift; sourceTree = "<group>"; };
 		443A9CE12552B179009D3D34 /* IssueEndPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueEndPoint.swift; sourceTree = "<group>"; };
+		444C9A3E255C6CAA0098C437 /* LabelUseCaseType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelUseCaseType.swift; sourceTree = "<group>"; };
 		44791037255A70CB004366B2 /* DimmedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DimmedViewController.swift; sourceTree = "<group>"; };
 		4479103B255A7522004366B2 /* EditingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditingView.swift; sourceTree = "<group>"; };
 		44791043255A7C2F004366B2 /* AnimatableButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimatableButton.swift; sourceTree = "<group>"; };
@@ -173,7 +175,7 @@
 		B96FDAE4255C03CC00A1251C /* UIColor+hex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+hex.swift"; sourceTree = "<group>"; };
 		B96FDAE9255C0E7700A1251C /* LabelListUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelListUseCase.swift; sourceTree = "<group>"; };
 		B96FDAEF255C0E8200A1251C /* LabelEndPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelEndPoint.swift; sourceTree = "<group>"; };
-		B96FDAF3255C107C00A1251C /* LabelResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelResponse.swift; sourceTree = "<group>"; };
+		B96FDAF3255C107C00A1251C /* LabelListResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelListResponse.swift; sourceTree = "<group>"; };
 		B980375925484A14002FF4BF /* IssueTracker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = IssueTracker.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B980375C25484A14002FF4BF /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		B980375E25484A14002FF4BF /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -226,6 +228,7 @@
 				44791037255A70CB004366B2 /* DimmedViewController.swift */,
 				B96FDADB255BC89900A1251C /* Model */,
 				4479103B255A7522004366B2 /* EditingView.swift */,
+				444C9A3E255C6CAA0098C437 /* LabelUseCaseType.swift */,
 				448F3D91255BFE6E006397F3 /* LabelEditViewController.swift */,
 				448F3DA1255C0875006397F3 /* LabelEditingView.swift */,
 				448F3D85255BEFDD006397F3 /* LabelEditingView.xib */,
@@ -313,7 +316,7 @@
 				44791047255AB7CE004366B2 /* Label.swift */,
 				B96FDAE9255C0E7700A1251C /* LabelListUseCase.swift */,
 				B96FDAEF255C0E8200A1251C /* LabelEndPoint.swift */,
-				B96FDAF3255C107C00A1251C /* LabelResponse.swift */,
+				B96FDAF3255C107C00A1251C /* LabelListResponse.swift */,
 			);
 			path = LabelListScene;
 			sourceTree = "<group>";
@@ -698,7 +701,7 @@
 				44791048255AB7CE004366B2 /* Label.swift in Sources */,
 				44EA5D95255032A8008AB0EB /* IssueListViewController.swift in Sources */,
 				B907430A2551C5E400E1D2E6 /* LabelCoordinator.swift in Sources */,
-				B96FDAF4255C107C00A1251C /* LabelResponse.swift in Sources */,
+				B96FDAF4255C107C00A1251C /* LabelListResponse.swift in Sources */,
 				B9FBB4EB25517D66007207AE /* TabBarCoordinator.swift in Sources */,
 				B95A6C80254ADA1C00D9EC66 /* String+isNickNamePattern.swift in Sources */,
 				B95A6C78254AD03300D9EC66 /* String+isPasswordPattern.swift in Sources */,
@@ -716,6 +719,7 @@
 				B9013EBE2554227700B98C10 /* IssueDetailPullUpViewController.swift in Sources */,
 				4403B40D25494B5400503E17 /* InputView.swift in Sources */,
 				44791038255A70CB004366B2 /* DimmedViewController.swift in Sources */,
+				444C9A3F255C6CAA0098C437 /* LabelUseCaseType.swift in Sources */,
 				442B3DAA255265B800069D18 /* PaddingLabel.swift in Sources */,
 				44E910A6254ACF2A000949A1 /* SignUpInfo.swift in Sources */,
 				B949F990254EFB9100477211 /* LoginInfo.swift in Sources */,

--- a/iOS/IssueTracker/IssueTracker/Common/Model/NetworkRequest.swift
+++ b/iOS/IssueTracker/IssueTracker/Common/Model/NetworkRequest.swift
@@ -11,6 +11,7 @@ enum RequestMethod: String {
     case get = "GET"
     case post = "POST"
     case put = "PUT"
+    case delete = "DELETE"
 }
 
 protocol RequestType {

--- a/iOS/IssueTracker/IssueTracker/Coordinator/LabelCoordinator.swift
+++ b/iOS/IssueTracker/IssueTracker/Coordinator/LabelCoordinator.swift
@@ -33,8 +33,22 @@ final class LabelCoordinator: NavigationCoordinator {
 }
 
 extension LabelCoordinator {
-    func showEdit() {
-        let viewController = LabelEditViewController()
+    func showEdit(label: Label, _ delegate: LabelEditViewControllerDelegate) {
+        let viewController = LabelEditViewController(
+            useCase: LabelEditUseCase(networkService: networkService),
+            label: label
+        )
+        viewController.delegate = delegate
+        viewController.modalPresentationStyle = .overFullScreen
+        navigationController?.present(viewController, animated: true)
+    }
+    
+    func showCreate(label: Label, _ delegate: LabelEditViewControllerDelegate) {
+        let viewController = LabelEditViewController(
+            useCase: LabelCreateUseCase(networkService: networkService),
+            label: label
+        )
+        viewController.delegate = delegate
         viewController.modalPresentationStyle = .overFullScreen
         navigationController?.present(viewController, animated: true)
     }

--- a/iOS/IssueTracker/IssueTracker/EditingScene/DimmedViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/EditingScene/DimmedViewController.swift
@@ -36,12 +36,12 @@ extension DimmedViewController {
         ])
     }
     
-    @objc func dismissWithAnimation() {
+    @objc func dismissWithAnimation(completion: (() -> Void)? = nil) {
         let animator = UIViewPropertyAnimator(duration: 0.25, curve: .linear) { [weak self] in
             self?.backgroundView.alpha = 0
         }
         animator.addCompletion { [weak self] _ in
-            self?.dismiss(animated: true)
+            self?.dismiss(animated: true, completion: completion)
         }
         animator.startAnimation()
     }

--- a/iOS/IssueTracker/IssueTracker/EditingScene/DimmedViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/EditingScene/DimmedViewController.swift
@@ -36,12 +36,12 @@ extension DimmedViewController {
         ])
     }
     
-    @objc func dismissWithAnimation(completion: (() -> Void)? = nil) {
+    @objc func dismissWithAnimation() {
         let animator = UIViewPropertyAnimator(duration: 0.25, curve: .linear) { [weak self] in
             self?.backgroundView.alpha = 0
         }
         animator.addCompletion { [weak self] _ in
-            self?.dismiss(animated: true, completion: completion)
+            self?.dismiss(animated: true)
         }
         animator.startAnimation()
     }

--- a/iOS/IssueTracker/IssueTracker/EditingScene/LabelEditViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/EditingScene/LabelEditViewController.swift
@@ -77,7 +77,7 @@ extension LabelEditViewController: LabelEditingViewDelegate {
     }
     
     func colorGenerated(_ labelEditingView: LabelEditingView) {
-        guard let color = RandomHexColorGenerator.generateExcept(for: label.color) else { return }
+        guard let color = RandomHexColorGenerator.generate(exceptFor: label.color) else { return }
         label.color = color
     }
 }

--- a/iOS/IssueTracker/IssueTracker/EditingScene/LabelEditViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/EditingScene/LabelEditViewController.swift
@@ -17,6 +17,7 @@ final class LabelEditViewController: DimmedViewController {
     private let useCase: LabelUseCaseType
     private var label: Label {
         didSet {
+            guard oldValue.color != label.color else { return }
             editingView.update(with: label)
         }
     }

--- a/iOS/IssueTracker/IssueTracker/EditingScene/LabelEditViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/EditingScene/LabelEditViewController.swift
@@ -52,9 +52,8 @@ extension LabelEditViewController: EditingViewDelegate {
             guard let self = self else { return }
             DispatchQueue.main.async {
                 guard let error = error else {
-                    self.dismissWithAnimation(completion: {
-                        self.delegate?.labelChanged(self)
-                    })
+                    self.dismissWithAnimation()
+                    self.delegate?.labelChanged(self)
                     return
                 }
                 self.alert(message: error.localizedDescription)

--- a/iOS/IssueTracker/IssueTracker/EditingScene/LabelEditingView.swift
+++ b/iOS/IssueTracker/IssueTracker/EditingScene/LabelEditingView.swift
@@ -7,7 +7,20 @@
 
 import UIKit
 
+protocol LabelEditingViewDelegate: class {
+    func titleChanged(_ labelEditingView: LabelEditingView, value: String)
+    func descriptionChanged(_ labelEditingView: LabelEditingView, value: String)
+    func colorChanged(_ labelEditingView: LabelEditingView, value: String)
+    func colorGenerated(_ labelEditingView: LabelEditingView)
+}
+
 final class LabelEditingView: EditingView, XibLoadable {
+    
+    @IBOutlet private weak var titleTextField: UITextField!
+    @IBOutlet private weak var descriptionTextField: UITextField!
+    @IBOutlet private weak var colorTextField: UITextField!
+    @IBOutlet private weak var colorView: ShadowView!
+    weak var labelEditingDelegate: LabelEditingViewDelegate?
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -17,6 +30,37 @@ final class LabelEditingView: EditingView, XibLoadable {
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         configure()
+    }
+    
+    @IBAction private func generateColorButtonDidTouchUp(_ sender: UIButton) {
+        labelEditingDelegate?.colorGenerated(self)
+    }
+}
+
+extension LabelEditingView {
+    func update(with label: Label) {
+        titleTextField.text = label.title
+        descriptionTextField.text = label.description
+        colorTextField.text = label.color
+        UIViewPropertyAnimator(duration: 0.25, curve: .easeInOut) { [weak self] in
+            self?.colorView.backgroundColor = UIColor(from: label.color)
+        }.startAnimation()
+    }
+}
+
+extension LabelEditingView: UITextFieldDelegate {
+    func textFieldDidChangeSelection(_ textField: UITextField) {
+        guard let value = textField.text else { return }
+        switch textField {
+        case titleTextField:
+            labelEditingDelegate?.titleChanged(self, value: value)
+        case descriptionTextField:
+            labelEditingDelegate?.descriptionChanged(self, value: value)
+        case colorTextField:
+            labelEditingDelegate?.colorChanged(self, value: value)
+        default:
+            break
+        }
     }
 }
 

--- a/iOS/IssueTracker/IssueTracker/EditingScene/LabelEditingView.xib
+++ b/iOS/IssueTracker/IssueTracker/EditingScene/LabelEditingView.xib
@@ -8,7 +8,14 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="LabelEditingView" customModule="IssueTracker" customModuleProvider="target"/>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="LabelEditingView" customModule="IssueTracker" customModuleProvider="target">
+            <connections>
+                <outlet property="colorTextField" destination="s22-UE-QbD" id="ehU-yA-yfQ"/>
+                <outlet property="colorView" destination="1iW-uv-Ewr" id="ddW-Xl-gCt"/>
+                <outlet property="descriptionTextField" destination="5yK-BS-nkd" id="akx-pz-X1h"/>
+                <outlet property="titleTextField" destination="Sc3-A2-u9a" id="gnq-eg-09j"/>
+            </connections>
+        </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="iN0-l3-epB">
             <rect key="frame" x="0.0" y="0.0" width="300" height="210"/>
@@ -36,6 +43,9 @@
                                             <rect key="frame" x="62" y="28.5" width="238" height="22"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <textInputTraits key="textInputTraits"/>
+                                            <connections>
+                                                <outlet property="delegate" destination="-1" id="5Pn-pn-iTs"/>
+                                            </connections>
                                         </textField>
                                     </subviews>
                                 </stackView>
@@ -67,6 +77,9 @@
                                             <rect key="frame" x="62" y="28" width="238" height="22"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <textInputTraits key="textInputTraits"/>
+                                            <connections>
+                                                <outlet property="delegate" destination="-1" id="ZNG-bP-qHV"/>
+                                            </connections>
                                         </textField>
                                     </subviews>
                                 </stackView>
@@ -98,8 +111,11 @@
                                             <rect key="frame" x="62" y="28.5" width="99" height="22"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <textInputTraits key="textInputTraits"/>
+                                            <connections>
+                                                <outlet property="delegate" destination="-1" id="nHg-xz-kOm"/>
+                                            </connections>
                                         </textField>
-                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1iW-uv-Ewr" customClass="ShadowButton" customModule="IssueTracker" customModuleProvider="target">
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1iW-uv-Ewr" customClass="ShadowView" customModule="IssueTracker" customModuleProvider="target">
                                             <rect key="frame" x="177" y="20.5" width="74" height="30"/>
                                             <color key="backgroundColor" systemColor="systemTealColor"/>
                                             <constraints>
@@ -128,6 +144,9 @@
                                                     <real key="value" value="16.5"/>
                                                 </userDefinedRuntimeAttribute>
                                             </userDefinedRuntimeAttributes>
+                                            <connections>
+                                                <action selector="generateColorButtonDidTouchUp:" destination="-1" eventType="touchUpInside" id="tKM-z2-qB4"/>
+                                            </connections>
                                         </button>
                                     </subviews>
                                 </stackView>
@@ -158,9 +177,6 @@
     <designables>
         <designable name="050-1b-GGT">
             <size key="intrinsicContentSize" width="20" height="22"/>
-        </designable>
-        <designable name="1iW-uv-Ewr">
-            <size key="intrinsicContentSize" width="30" height="34"/>
         </designable>
     </designables>
     <resources>

--- a/iOS/IssueTracker/IssueTracker/EditingScene/LabelUseCaseType.swift
+++ b/iOS/IssueTracker/IssueTracker/EditingScene/LabelUseCaseType.swift
@@ -1,0 +1,72 @@
+//
+//  LabelUseCaseType.swift
+//  IssueTracker
+//
+//  Created by TTOzzi on 2020/11/12.
+//
+
+import Foundation
+
+protocol LabelUseCaseType {
+    func save(label: Label, completion: @escaping (UseCaseError?) -> Void)
+}
+
+struct LabelEditUseCase: LabelUseCaseType {
+    
+    private let networkService: NetworkServiceProviding
+    
+    init(networkService: NetworkServiceProviding) {
+        self.networkService = networkService
+    }
+    
+    func save(label: Label, completion: @escaping (UseCaseError?) -> Void) {
+        let info = [
+            "title": label.title,
+            "color": label.color,
+            "description": label.description
+        ]
+        guard let data = try? JSONEncoder().encode(info) else {
+            completion(.encodingError)
+            return
+        }
+        let request = LabelEndPoint(path: .label(id: label.id), method: .put, body: data)
+        networkService.request(requestType: request) { result in
+            switch result {
+            case .success:
+                completion(nil)
+            case let .failure(error):
+                completion(.networkError(message: error.localizedDescription))
+            }
+        }
+    }
+}
+
+struct LabelCreateUseCase: LabelUseCaseType {
+    
+    private let networkService: NetworkServiceProviding
+    
+    init(networkService: NetworkServiceProviding) {
+        self.networkService = networkService
+    }
+    
+    func save(label: Label, completion: @escaping (UseCaseError?) -> Void) {
+        let info = [
+            "title": label.title,
+            "color": label.color,
+            "description": label.description
+        ]
+        guard let data = try? JSONEncoder().encode(info) else {
+            completion(.encodingError)
+            return
+        }
+        let request = LabelEndPoint(path: .labels, method: .post, body: data)
+        networkService.request(requestType: request) { result in
+            switch result {
+            case .success:
+                completion(nil)
+            case let .failure(error):
+                completion(.networkError(message: error.localizedDescription))
+            }
+        }
+    }
+}

--- a/iOS/IssueTracker/IssueTracker/EditingScene/Model/RandomHexColorGenerator.swift
+++ b/iOS/IssueTracker/IssueTracker/EditingScene/Model/RandomHexColorGenerator.swift
@@ -15,13 +15,13 @@ final class RandomHexColorGenerator {
         return "#\(newValue)"
     }
     
-    static func generateExcept(for current: String) -> String? {
+    static func generate(exceptFor current: String) -> String? {
         guard !current.isEmpty,
               current.first == "#",
               current.count == 7,
               current.enumerated().allSatisfy({ $0 == 0 || $1.isHexDigit }) else { return nil }
         let uppercasedCurrent = current.uppercased()
         let result = generate()
-        return result == uppercasedCurrent ? generateExcept(for: uppercasedCurrent) : result
+        return result == uppercasedCurrent ? generate(exceptFor: uppercasedCurrent) : result
     }
 }

--- a/iOS/IssueTracker/IssueTracker/EditingScene/Model/RandomHexColorGenerator.swift
+++ b/iOS/IssueTracker/IssueTracker/EditingScene/Model/RandomHexColorGenerator.swift
@@ -9,15 +9,19 @@ import Foundation
 
 final class RandomHexColorGenerator {
     
-    func generateExcept(for current: String) -> String? {
+    static func generate() -> String {
         let hexDigit = "0123456789ABCDEF"
+        let newValue = String((0..<6).compactMap({_ in hexDigit.randomElement()}))
+        return "#\(newValue)"
+    }
+    
+    static func generateExcept(for current: String) -> String? {
         guard !current.isEmpty,
               current.first == "#",
               current.count == 7,
               current.enumerated().allSatisfy({ $0 == 0 || $1.isHexDigit }) else { return nil }
         let uppercasedCurrent = current.uppercased()
-        let newValue = String((0..<6).compactMap({_ in hexDigit.randomElement()}))
-        let result = "#\(newValue)"
+        let result = generate()
         return result == uppercasedCurrent ? generateExcept(for: uppercasedCurrent) : result
     }
 }

--- a/iOS/IssueTracker/IssueTracker/IssueListScene/IssueListViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/IssueListScene/IssueListViewController.swift
@@ -112,9 +112,9 @@ private extension IssueListViewController {
                 style: .destructive,
                 title: Constant.closeActionTitle,
                 handler: { [weak self] _, _, _ in
-                    guard let self = self else { return }
-                    let id = self.issues[indexPath.item].id
-                    self.closeIssue(with: id)
+                    guard let self = self,
+                          let issue = self.dataSource.itemIdentifier(for: indexPath) else { return }
+                    self.closeIssue(with: issue.id)
                     self.issues.remove(at: indexPath.item)
                 }
             )

--- a/iOS/IssueTracker/IssueTracker/LabelListScene/Label.swift
+++ b/iOS/IssueTracker/IssueTracker/LabelListScene/Label.swift
@@ -9,7 +9,13 @@ import Foundation
 
 struct Label: Hashable, Decodable {
     let id: Int
-    let title: String
-    let color: String
-    let description: String?
+    var title: String
+    var color: String
+    var description: String?
+    
+    mutating func reset() {
+        title = ""
+        color = "#FFFFFF"
+        description = nil
+    }
 }

--- a/iOS/IssueTracker/IssueTracker/LabelListScene/LabelCollectionViewCell.swift
+++ b/iOS/IssueTracker/IssueTracker/LabelListScene/LabelCollectionViewCell.swift
@@ -25,6 +25,14 @@ final class LabelCollectionViewCell: UICollectionViewListCell {
         configure()
     }
     
+    override func updateConfiguration(using state: UICellConfigurationState) {
+        super.updateConfiguration(using: state)
+        guard state.isSelected || state.isHighlighted else { return }
+        backgroundConfiguration?.backgroundColor = .clear
+    }
+}
+
+extension LabelCollectionViewCell {
     func update(with label: Label) {
         labelLabel.text = label.title
         descriptionLabel.text = label.description

--- a/iOS/IssueTracker/IssueTracker/LabelListScene/LabelEndPoint.swift
+++ b/iOS/IssueTracker/IssueTracker/LabelListScene/LabelEndPoint.swift
@@ -11,11 +11,14 @@ struct LabelEndPoint: RequestType {
     
     enum Path: CustomStringConvertible {
         case labels
+        case label(id: Int)
         
         var description: String {
             switch self {
             case .labels:
                 return "/label"
+            case let .label(id):
+                return "/label/\(id)"
             }
         }
     }

--- a/iOS/IssueTracker/IssueTracker/LabelListScene/LabelListResponse.swift
+++ b/iOS/IssueTracker/IssueTracker/LabelListScene/LabelListResponse.swift
@@ -7,6 +7,10 @@
 
 import Foundation
 
-struct LabelResponse: Decodable {
+struct LabelListResponse: Decodable {
     let labels: [Label]
+}
+
+struct LabelResponse: Decodable {
+    let label: Label
 }

--- a/iOS/IssueTracker/IssueTracker/LabelListScene/LabelListUseCase.swift
+++ b/iOS/IssueTracker/IssueTracker/LabelListScene/LabelListUseCase.swift
@@ -9,6 +9,8 @@ import Foundation
 
 protocol LabelListUseCaseType {
     func loadList(completion: @escaping (Result<[Label], UseCaseError>) -> Void)
+    func loadLabel(for id: Int, completion: @escaping (Result<Label, UseCaseError>) -> Void)
+    func removeLabel(for id: Int, completion: @escaping (UseCaseError?) -> Void)
 }
 
 struct LabelListUseCase: LabelListUseCaseType {
@@ -24,13 +26,41 @@ struct LabelListUseCase: LabelListUseCaseType {
         networkService.request(requestType: request) { result in
             switch result {
             case let .success(data):
-                guard let response = try? JSONDecoder().decode(LabelResponse.self, from: data) else {
+                guard let response = try? JSONDecoder().decode(LabelListResponse.self, from: data) else {
                     completion(.failure(.decodingError))
                     return
                 }
                 completion(.success(response.labels))
             case let .failure(error):
                 completion(.failure(.networkError(message: error.localizedDescription)))
+            }
+        }
+    }
+    
+    func loadLabel(for id: Int, completion: @escaping (Result<Label, UseCaseError>) -> Void) {
+        let request = LabelEndPoint(path: .label(id: id), method: .get)
+        networkService.request(requestType: request) { result in
+            switch result {
+            case let .success(data):
+                guard let response = try? JSONDecoder().decode(LabelResponse.self, from: data) else {
+                    completion(.failure(.decodingError))
+                    return
+                }
+                completion(.success(response.label))
+            case let .failure(error):
+                completion(.failure(.networkError(message: error.localizedDescription)))
+            }
+        }
+    }
+    
+    func removeLabel(for id: Int, completion: @escaping (UseCaseError?) -> Void) {
+        let request = LabelEndPoint(path: .label(id: id), method: .delete)
+        networkService.request(requestType: request) { result in
+            switch result {
+            case .success:
+                completion(nil)
+            case let .failure(error):
+                completion(.networkError(message: error.localizedDescription))
             }
         }
     }

--- a/iOS/IssueTracker/IssueTracker/LabelListScene/LabelListViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/LabelListScene/LabelListViewController.swift
@@ -77,7 +77,6 @@ private extension LabelListViewController {
             )
             return UISwipeActionsConfiguration(actions: [closeAction])
         }
-
         return UICollectionViewCompositionalLayout.list(using: configuration)
     }
 }

--- a/iOS/IssueTracker/IssueTracker/LabelListScene/LabelListViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/LabelListScene/LabelListViewController.swift
@@ -38,15 +38,46 @@ final class LabelListViewController: UIViewController {
     }
 }
 
-private extension LabelListViewController {
-    @objc func addButtonDidTouchUp() {
-        coordinator?.showEdit()
+extension LabelListViewController: LabelEditViewControllerDelegate {
+    func labelChanged(_ labelEditViewController: LabelEditViewController) {
+        loadList()
+    }
+}
+
+extension LabelListViewController: UICollectionViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        guard let selectedLabel = dataSource.itemIdentifier(for: indexPath) else { return }
+        useCase.loadLabel(for: selectedLabel.id) { [weak self] result in
+            guard let self = self else { return }
+            DispatchQueue.main.async {
+                switch result {
+                case let .success(label):
+                    self.coordinator?.showEdit(label: label, self)
+                case let .failure(error):
+                    self.alert(message: error.localizedDescription)
+                }
+            }
+        }
     }
 }
 
 private extension LabelListViewController {
     func labelCollectionViewLayout() -> UICollectionViewCompositionalLayout {
-        let configuration = UICollectionLayoutListConfiguration(appearance: .plain)
+        var configuration = UICollectionLayoutListConfiguration(appearance: .plain)
+        configuration.trailingSwipeActionsConfigurationProvider = { indexPath in
+            let closeAction = UIContextualAction(
+                style: .destructive,
+                title: "Delete",
+                handler: { [weak self] _, _, _ in
+                    guard let self = self,
+                          let label = self.dataSource.itemIdentifier(for: indexPath) else { return }
+                    self.remove(with: label.id)
+                    self.labels.remove(at: indexPath.item)
+                }
+            )
+            return UISwipeActionsConfiguration(actions: [closeAction])
+        }
+
         return UICollectionViewCompositionalLayout.list(using: configuration)
     }
 }
@@ -96,6 +127,24 @@ private extension LabelListViewController {
             }
         }
     }
+    
+    func remove(with id: Int) {
+        useCase.removeLabel(for: id) { [weak self] error in
+            guard let error = error else {
+                self?.loadList()
+                return
+            }
+            self?.alert(message: error.localizedDescription)
+        }
+    }
+    
+    @objc func addButtonDidTouchUp() {
+        let newLabel = Label(id: 0,
+                             title: "",
+                             color: RandomHexColorGenerator.generate(),
+                             description: nil)
+        coordinator?.showCreate(label: newLabel, self)
+    }
 }
 
 private extension LabelListViewController {
@@ -113,8 +162,8 @@ private extension LabelListViewController {
     }
     
     func configureCollectionView() {
+        labelCollectionView.delegate = self
         labelCollectionView.dataSource = dataSource
         labelCollectionView.setCollectionViewLayout(labelCollectionViewLayout(), animated: true)
-        labelCollectionView.allowsSelection = false
     }
 }


### PR DESCRIPTION
레이블 추가, 수정, 삭제 기능 구현
삭제 요청을 위한 delete RequestMethod 추가
생성화면, 수정화면 구분을 위해 UseCase를 각각 따로 생성, 둘 다 LabelUseCaseType을 채택하고 내부 메서드만 다르게 구현함
LabelCoordinator에서 생성, 수정화면에 맞게 UseCase를 생성하여 주입
Delegate를 활용하여 편집 뷰 -> 뷰컨트롤러 이벤트처리
레이블 리스트 화면에서 스와이프시 레이블 삭제 구현, 로직은 이슈 리스트 화면과 동일

<img width="40%" src="https://user-images.githubusercontent.com/50410213/98861017-eda3b780-24a7-11eb-82ab-d9ad1ee244b3.gif">

관련된 기능을 한번에 구현하다보니 작업내용이 많아졌네요😅

#164 #166