### PR TITLE
키보드 관련 버그 해결, 화면크기 대응

### DIFF
--- a/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
+++ b/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		448F3DA2255C0875006397F3 /* LabelEditingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 448F3DA1255C0875006397F3 /* LabelEditingView.swift */; };
 		449CE3292559332100A56AEB /* IssueCreateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 449CE3282559332100A56AEB /* IssueCreateViewController.swift */; };
 		44ABCDE12558D95F0023457B /* UseCaseError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44ABCDE02558D95F0023457B /* UseCaseError.swift */; };
+		44D51A55255D4BF200780FD4 /* KeyboardObservableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44D51A54255D4BF200780FD4 /* KeyboardObservableViewController.swift */; };
 		44E910A3254ACEC7000949A1 /* SignUpUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44E910A2254ACEC7000949A1 /* SignUpUseCase.swift */; };
 		44E910A6254ACF2A000949A1 /* SignUpInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44E910A5254ACF2A000949A1 /* SignUpInfo.swift */; };
 		44E910A9254AD1C7000949A1 /* SignUpEndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44E910A8254AD1C7000949A1 /* SignUpEndPoint.swift */; };
@@ -129,6 +130,7 @@
 		448F3DA1255C0875006397F3 /* LabelEditingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelEditingView.swift; sourceTree = "<group>"; };
 		449CE3282559332100A56AEB /* IssueCreateViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueCreateViewController.swift; sourceTree = "<group>"; };
 		44ABCDE02558D95F0023457B /* UseCaseError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UseCaseError.swift; sourceTree = "<group>"; };
+		44D51A54255D4BF200780FD4 /* KeyboardObservableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardObservableViewController.swift; sourceTree = "<group>"; };
 		44E910A2254ACEC7000949A1 /* SignUpUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpUseCase.swift; sourceTree = "<group>"; };
 		44E910A5254ACF2A000949A1 /* SignUpInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpInfo.swift; sourceTree = "<group>"; };
 		44E910A8254AD1C7000949A1 /* SignUpEndPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpEndPoint.swift; sourceTree = "<group>"; };
@@ -413,6 +415,7 @@
 				448F3D8D255BFE1A006397F3 /* XibLoadable.swift */,
 				44791037255A70CB004366B2 /* DimmedViewController.swift */,
 				4479103B255A7522004366B2 /* EditingView.swift */,
+				44D51A54255D4BF200780FD4 /* KeyboardObservableViewController.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -695,6 +698,7 @@
 				B95A6C74254ACE9E00D9EC66 /* String+isEmailPattern.swift in Sources */,
 				B9013EBE2554227700B98C10 /* IssueDetailPullUpViewController.swift in Sources */,
 				4403B40D25494B5400503E17 /* InputView.swift in Sources */,
+				44D51A55255D4BF200780FD4 /* KeyboardObservableViewController.swift in Sources */,
 				44791038255A70CB004366B2 /* DimmedViewController.swift in Sources */,
 				444C9A3F255C6CAA0098C437 /* LabelUseCaseType.swift in Sources */,
 				442B3DAA255265B800069D18 /* PaddingLabel.swift in Sources */,

--- a/iOS/IssueTracker/IssueTracker/Common/View/DimmedViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/Common/View/DimmedViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class DimmedViewController: UIViewController {
+class DimmedViewController: KeyboardObservableViewController {
     
     private let backgroundView: UIView = UIView()
     
@@ -20,6 +20,19 @@ class DimmedViewController: UIViewController {
         super.viewDidAppear(animated)
         UIViewPropertyAnimator(duration: 0.25, curve: .linear) { [weak self] in
             self?.backgroundView.alpha = 0.3
+        }.startAnimation()
+    }
+    
+    override func keyboardWillShow(_ notification: NSNotification) {
+        guard let keyboardFrame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue,
+              let activeView = activeView else { return }
+        let keyboardHeight = keyboardFrame.cgRectValue.height
+        let activeViewOrigin = activeView.frame.origin
+        let activeViewHeight = activeViewOrigin.y + activeView.frame.height
+        let displayAreaHeight = view.frame.height - keyboardHeight
+        UIViewPropertyAnimator(duration: 0.25, curve: .easeInOut) { [weak self] in
+            self?.view.transform = activeViewHeight > displayAreaHeight ?
+                CGAffineTransform(translationX: 0, y: -(activeViewHeight - displayAreaHeight)) : .identity
         }.startAnimation()
     }
 }

--- a/iOS/IssueTracker/IssueTracker/Common/View/InputView.swift
+++ b/iOS/IssueTracker/IssueTracker/Common/View/InputView.swift
@@ -15,7 +15,11 @@ final class InputView: UIView {
     
     private let label: UILabel = UILabel()
     let textField: UITextField = UITextField()
-    weak var delegate: InputViewDelegate?
+    weak var delegate: InputViewDelegate? {
+        didSet {
+            textField.delegate = delegate as? UITextFieldDelegate
+        }
+    }
 
     @IBInspectable var title: String? {
         get { label.text }

--- a/iOS/IssueTracker/IssueTracker/Common/View/KeyboardObservableViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/Common/View/KeyboardObservableViewController.swift
@@ -1,0 +1,57 @@
+//
+//  KeyboardObservableViewController.swift
+//  IssueTracker
+//
+//  Created by TTOzzi on 2020/11/12.
+//
+
+import UIKit
+
+class KeyboardObservableViewController: UIViewController {
+    
+    var activeView: UIView?
+    
+    override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
+        super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
+        configureKeyboardObservers()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        configureKeyboardObservers()
+    }
+    
+    func configureKeyboardObservers() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(keyboardWillShow),
+            name: UIResponder.keyboardWillShowNotification,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(keyboardWillHide),
+            name: UIResponder.keyboardWillHideNotification,
+            object: nil
+        )
+    }
+    
+    @objc func keyboardWillShow(_ notification: NSNotification) {
+        guard let keyboardFrame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue,
+              let activeView = activeView else { return }
+        let keyboardHeight = keyboardFrame.cgRectValue.height
+        let activeViewOrigin = activeView.frame.origin
+        let activeViewHeight = activeView.convert(activeViewOrigin, to: view).y + activeView.frame.height
+        let displayAreaHeight = view.frame.height - keyboardHeight
+        UIViewPropertyAnimator(duration: 0.25, curve: .easeInOut) { [weak self] in
+            self?.view.transform = activeViewHeight > displayAreaHeight ?
+                CGAffineTransform(translationX: 0, y: -(activeViewHeight - displayAreaHeight)) : .identity
+        }.startAnimation()
+    }
+    
+    @objc func keyboardWillHide() {
+        UIViewPropertyAnimator(duration: 0.25, curve: .easeInOut) { [weak self] in
+            self?.view.transform = .identity
+        }.startAnimation()
+    }
+}

--- a/iOS/IssueTracker/IssueTracker/LabelListScene/LabelEditingScene/LabelEditViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/LabelListScene/LabelEditingScene/LabelEditViewController.swift
@@ -80,6 +80,10 @@ extension LabelEditViewController: LabelEditingViewDelegate {
         guard let color = RandomHexColorGenerator.generate(exceptFor: label.color) else { return }
         label.color = color
     }
+    
+    func editingDidChanged(_ labelEditingView: LabelEditingView, isEditing: Bool) {
+        activeView = isEditing ? editingView : nil
+    }
 }
 
 private extension LabelEditViewController {

--- a/iOS/IssueTracker/IssueTracker/LabelListScene/LabelEditingScene/LabelEditingView.swift
+++ b/iOS/IssueTracker/IssueTracker/LabelListScene/LabelEditingScene/LabelEditingView.swift
@@ -12,6 +12,7 @@ protocol LabelEditingViewDelegate: class {
     func descriptionChanged(_ labelEditingView: LabelEditingView, value: String)
     func colorChanged(_ labelEditingView: LabelEditingView, value: String)
     func colorGenerated(_ labelEditingView: LabelEditingView)
+    func editingDidChanged(_ labelEditingView: LabelEditingView, isEditing: Bool)
 }
 
 final class LabelEditingView: EditingView, XibLoadable {
@@ -49,6 +50,22 @@ extension LabelEditingView {
 }
 
 extension LabelEditingView: UITextFieldDelegate {
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        switch textField {
+        case titleTextField:
+            titleTextField.resignFirstResponder()
+            descriptionTextField.becomeFirstResponder()
+        case descriptionTextField:
+            descriptionTextField.resignFirstResponder()
+            colorTextField.becomeFirstResponder()
+        case colorTextField:
+            colorTextField.resignFirstResponder()
+        default:
+            break
+        }
+        return true
+    }
+    
     func textFieldDidChangeSelection(_ textField: UITextField) {
         guard let value = textField.text else { return }
         switch textField {
@@ -61,6 +78,14 @@ extension LabelEditingView: UITextFieldDelegate {
         default:
             break
         }
+    }
+    
+    func textFieldDidBeginEditing(_ textField: UITextField) {
+        labelEditingDelegate?.editingDidChanged(self, isEditing: true)
+    }
+    
+    func textFieldDidEndEditing(_ textField: UITextField) {
+        labelEditingDelegate?.editingDidChanged(self, isEditing: false)
     }
 }
 

--- a/iOS/IssueTracker/IssueTracker/LabelListScene/LabelEditingScene/LabelEditingView.swift
+++ b/iOS/IssueTracker/IssueTracker/LabelListScene/LabelEditingScene/LabelEditingView.swift
@@ -87,6 +87,16 @@ extension LabelEditingView: UITextFieldDelegate {
     func textFieldDidEndEditing(_ textField: UITextField) {
         labelEditingDelegate?.editingDidChanged(self, isEditing: false)
     }
+    
+    func textField(_ textField: UITextField,
+                   shouldChangeCharactersIn range: NSRange,
+                   replacementString string: String) -> Bool {
+        guard textField == colorTextField else { return true }
+        guard let text = textField.text,
+              let changedRange = Range(range, in: text) else { return false }
+        let count = text.count - (text[changedRange].count + string.count)
+        return count <= 7
+    }
 }
 
 private extension LabelEditingView {

--- a/iOS/IssueTracker/IssueTracker/LabelListScene/LabelEditingScene/LabelEditingView.xib
+++ b/iOS/IssueTracker/IssueTracker/LabelListScene/LabelEditingScene/LabelEditingView.xib
@@ -95,7 +95,7 @@
                         <stackView opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="1000" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="ZMd-E4-FWe">
                             <rect key="frame" x="0.0" y="150.5" width="300" height="59.5"/>
                             <subviews>
-                                <stackView opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="1000" alignment="bottom" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="hcf-gX-8Va">
+                                <stackView opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="1000" alignment="bottom" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="hcf-gX-8Va">
                                     <rect key="frame" x="0.0" y="0.0" width="300" height="50.5"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="색상" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="z8o-Ko-vmM">
@@ -108,7 +108,7 @@
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="s22-UE-QbD">
-                                            <rect key="frame" x="62" y="28.5" width="99" height="22"/>
+                                            <rect key="frame" x="58" y="28.5" width="105" height="22"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <textInputTraits key="textInputTraits"/>
                                             <connections>
@@ -116,10 +116,10 @@
                                             </connections>
                                         </textField>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1iW-uv-Ewr" customClass="ShadowView" customModule="IssueTracker" customModuleProvider="target">
-                                            <rect key="frame" x="177" y="20.5" width="74" height="30"/>
+                                            <rect key="frame" x="175" y="20.5" width="80" height="30"/>
                                             <color key="backgroundColor" systemColor="systemTealColor"/>
                                             <constraints>
-                                                <constraint firstAttribute="width" constant="74" id="HmS-8q-QQf"/>
+                                                <constraint firstAttribute="width" relation="greaterThanOrEqual" priority="500" constant="74" id="HmS-8q-QQf"/>
                                                 <constraint firstAttribute="height" constant="30" id="WT3-Oe-qNU"/>
                                             </constraints>
                                             <userDefinedRuntimeAttributes>
@@ -167,6 +167,7 @@
             <constraints>
                 <constraint firstItem="Kpz-AW-IOy" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="FXC-sc-pK7"/>
                 <constraint firstAttribute="bottom" secondItem="Kpz-AW-IOy" secondAttribute="bottom" id="S09-rK-USQ"/>
+                <constraint firstItem="s22-UE-QbD" firstAttribute="width" secondItem="iN0-l3-epB" secondAttribute="width" multiplier="0.35" id="aYJ-Td-xlg"/>
                 <constraint firstAttribute="trailing" secondItem="Kpz-AW-IOy" secondAttribute="trailing" id="roq-OC-A8Q"/>
                 <constraint firstItem="Kpz-AW-IOy" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="xuv-AA-Y0p"/>
             </constraints>

--- a/iOS/IssueTracker/IssueTracker/LoginScene/LoginViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/LoginScene/LoginViewController.swift
@@ -13,8 +13,8 @@ final class LoginViewController: UIViewController {
     static var identifier: String {
         return String(describing: Self.self)
     }
-    @IBOutlet private weak var passwordInputView: InputView!
     @IBOutlet private weak var emailInputView: InputView!
+    @IBOutlet private weak var passwordInputView: InputView!
     @IBOutlet private weak var localLoginButton: UIButton!
     @IBOutlet private weak var githubLoginButton: UIButton!
     private let appleLoginButton: ASAuthorizationAppleIDButton = ASAuthorizationAppleIDButton()
@@ -134,6 +134,19 @@ extension LoginViewController: UITextFieldDelegate {
     private func configureInputViews() {
         passwordInputView.textField.delegate = self
         emailInputView.textField.delegate = self
+    }
+    
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        switch textField {
+        case emailInputView.textField:
+            emailInputView.textField.resignFirstResponder()
+            passwordInputView.textField.becomeFirstResponder()
+        case passwordInputView.textField:
+            passwordInputView.textField.resignFirstResponder()
+        default:
+            break
+        }
+        return true
     }
     
     func textFieldDidBeginEditing(_ textField: UITextField) {

--- a/iOS/IssueTracker/IssueTracker/SignUpScene/SignUpViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/SignUpScene/SignUpViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-final class SignUpViewController: UIViewController {
+final class SignUpViewController: KeyboardObservableViewController {
     
     static var identifier: String {
         return String(describing: Self.self)
@@ -19,7 +19,6 @@ final class SignUpViewController: UIViewController {
     @IBOutlet private weak var completeButton: UIButton!
     private let patternChecker: PatternChecker = PatternChecker()
     private let signUpUseCase: SignUpUseCase
-    private var activeTextField: UITextField?
     weak var coordinator: LoginCoordinator?
     
     init?(coder: NSCoder, useCase: SignUpUseCase) {
@@ -34,7 +33,6 @@ final class SignUpViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         configureInputViews()
-        configureObservers()
     }
     
     @IBAction private func completeButtonTouchUp(_ sender: UIButton) {
@@ -92,11 +90,11 @@ extension SignUpViewController: InputViewDelegate {
     }
     
     func textFieldDidBeginEditing(_ textField: UITextField) {
-        activeTextField = textField
+        activeView = textField
     }
     
     func textFieldDidEndEditing(_ textField: UITextField) {
-        activeTextField = nil
+        activeView = nil
     }
 }
 
@@ -106,41 +104,5 @@ private extension SignUpViewController {
         passwordInputView.delegate = self
         passwordConfirmInputView.delegate = self
         nameInputView.delegate = self
-    }
-}
-
-private extension SignUpViewController {
-    func configureObservers() {
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(keyboardWillShow),
-            name: UIResponder.keyboardWillShowNotification,
-            object: nil
-        )
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(keyboardWillHide),
-            name: UIResponder.keyboardWillHideNotification,
-            object: nil
-        )
-    }
-    
-    @objc func keyboardWillShow(_ notification: NSNotification) {
-        guard let keyboardFrame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue,
-              let textField = activeTextField else { return }
-        let keyboardHeight = keyboardFrame.cgRectValue.height
-        let textFieldOrigin = textField.frame.origin
-        let textFieldHeight = textField.convert(textFieldOrigin, to: nil).y + textField.frame.height
-        let displayAreaHeight = view.frame.height - keyboardHeight
-        UIViewPropertyAnimator(duration: 0.25, curve: .easeInOut) { [weak self] in
-            self?.view.transform = textFieldHeight > displayAreaHeight ?
-                CGAffineTransform(translationX: 0, y: -(textFieldHeight - displayAreaHeight)) : .identity
-        }.startAnimation()
-    }
-    
-    @objc func keyboardWillHide() {
-        UIViewPropertyAnimator(duration: 0.25, curve: .easeInOut) { [weak self] in
-            self?.view.transform = .identity
-        }.startAnimation()
     }
 }


### PR DESCRIPTION
UITextFieldDelegate와 UIResponder의 키보드 노티피케이션을 활용해 키보드에 의해 뷰가 가려지는 현상을 해결하였습니다.
중복 코드를 줄이기 위해 KeyboardObservableViewController를 생성해 키보드 위치를 계산하여 뷰를 올려주는 코드를 구현하고, 이를 상속받아 여러 뷰 컨트롤러에서 사용하게 구현하였습니다.

작은 화면에서 레이블 색상 TextField가 잘려서 나오는 문제를 compressionResistance의 우선순위를 조절하여 해결하였습니다.

UITextFieldDelegate의 shouldChangeCharactersIn 메서드를 활용해 레이블 색상 TextField의 글자수를 7글자(#포함 16진수 6글자)로제한하였습니다.

#222 #224 #226 